### PR TITLE
Backported version switcher to Cartopy v0.4 through to v0.6

### DIFF
--- a/cartopy/docs/v0.4/_modules/cartopy/mpl_integration/geoaxes.html
+++ b/cartopy/docs/v0.4/_modules/cartopy/mpl_integration/geoaxes.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/_modules/index.html
+++ b/cartopy/docs/v0.4/_modules/index.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/building_from_source/cartopy-0.0__on__osx-10.8.html
+++ b/cartopy/docs/v0.4/building_from_source/cartopy-0.0__on__osx-10.8.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/building_from_source/index.html
+++ b/cartopy/docs/v0.4/building_from_source/index.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/copyright.html
+++ b/cartopy/docs/v0.4/copyright.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/genindex.html
+++ b/cartopy/docs/v0.4/genindex.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/index.html
+++ b/cartopy/docs/v0.4/index.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/advanced_plotting.html
+++ b/cartopy/docs/v0.4/matplotlib/advanced_plotting.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/geoaxes.html
+++ b/cartopy/docs/v0.4/matplotlib/geoaxes.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/intro.html
+++ b/cartopy/docs/v0.4/matplotlib/intro.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/introductory_examples/01.great_circle.html
+++ b/cartopy/docs/v0.4/matplotlib/introductory_examples/01.great_circle.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/introductory_examples/02.polygon.html
+++ b/cartopy/docs/v0.4/matplotlib/introductory_examples/02.polygon.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/introductory_examples/03.contours.html
+++ b/cartopy/docs/v0.4/matplotlib/introductory_examples/03.contours.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/introductory_examples/04.images.html
+++ b/cartopy/docs/v0.4/matplotlib/introductory_examples/04.images.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/matplotlib/introductory_examples/index.html
+++ b/cartopy/docs/v0.4/matplotlib/introductory_examples/index.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/projections/index.html
+++ b/cartopy/docs/v0.4/projections/index.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/projections/table.html
+++ b/cartopy/docs/v0.4/projections/table.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/search.html
+++ b/cartopy/docs/v0.4/search.html
@@ -37,7 +37,10 @@
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.4/who_uses_cartopy.html
+++ b/cartopy/docs/v0.4/who_uses_cartopy.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/_modules/cartopy/io.html
+++ b/cartopy/docs/v0.5/_modules/cartopy/io.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/_modules/cartopy/mpl/geoaxes.html
+++ b/cartopy/docs/v0.5/_modules/cartopy/mpl/geoaxes.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/_modules/index.html
+++ b/cartopy/docs/v0.5/_modules/index.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/building_from_source/cartopy-0.0__on__osx-10.8.html
+++ b/cartopy/docs/v0.5/building_from_source/cartopy-0.0__on__osx-10.8.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/building_from_source/index.html
+++ b/cartopy/docs/v0.5/building_from_source/index.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/contributors.html
+++ b/cartopy/docs/v0.5/contributors.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/copyright.html
+++ b/cartopy/docs/v0.5/copyright.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/developer_interfaces.html
+++ b/cartopy/docs/v0.5/developer_interfaces.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/genindex.html
+++ b/cartopy/docs/v0.5/genindex.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/index.html
+++ b/cartopy/docs/v0.5/index.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/advanced_plotting.html
+++ b/cartopy/docs/v0.5/matplotlib/advanced_plotting.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/geoaxes.html
+++ b/cartopy/docs/v0.5/matplotlib/geoaxes.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/intro.html
+++ b/cartopy/docs/v0.5/matplotlib/intro.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/introductory_examples/01.great_circle.html
+++ b/cartopy/docs/v0.5/matplotlib/introductory_examples/01.great_circle.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/introductory_examples/02.polygon.html
+++ b/cartopy/docs/v0.5/matplotlib/introductory_examples/02.polygon.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/introductory_examples/03.contours.html
+++ b/cartopy/docs/v0.5/matplotlib/introductory_examples/03.contours.html
@@ -34,7 +34,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/introductory_examples/04.images.html
+++ b/cartopy/docs/v0.5/matplotlib/introductory_examples/04.images.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/matplotlib/introductory_examples/index.html
+++ b/cartopy/docs/v0.5/matplotlib/introductory_examples/index.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/projections/index.html
+++ b/cartopy/docs/v0.5/projections/index.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/projections/table.html
+++ b/cartopy/docs/v0.5/projections/table.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/search.html
+++ b/cartopy/docs/v0.5/search.html
@@ -37,7 +37,10 @@
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/whats_new.html
+++ b/cartopy/docs/v0.5/whats_new.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.5/who_uses_cartopy.html
+++ b/cartopy/docs/v0.5/who_uses_cartopy.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/linewidth.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/_modules/cartopy/feature.html
+++ b/cartopy/docs/v0.6/_modules/cartopy/feature.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/_modules/cartopy/io.html
+++ b/cartopy/docs/v0.6/_modules/cartopy/io.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/_modules/cartopy/io/shapereader.html
+++ b/cartopy/docs/v0.6/_modules/cartopy/io/shapereader.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/_modules/cartopy/mpl/geoaxes.html
+++ b/cartopy/docs/v0.6/_modules/cartopy/mpl/geoaxes.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/_modules/index.html
+++ b/cartopy/docs/v0.6/_modules/index.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/building_from_source/cartopy-0.0__on__osx-10.8.html
+++ b/cartopy/docs/v0.6/building_from_source/cartopy-0.0__on__osx-10.8.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/building_from_source/index.html
+++ b/cartopy/docs/v0.6/building_from_source/index.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/cartopy_outline.html
+++ b/cartopy/docs/v0.6/cartopy_outline.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/contributors.html
+++ b/cartopy/docs/v0.6/contributors.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/copyright.html
+++ b/cartopy/docs/v0.6/copyright.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/developer_interfaces.html
+++ b/cartopy/docs/v0.6/developer_interfaces.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/favicon.html
+++ b/cartopy/docs/v0.6/examples/favicon.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/feature_creation.html
+++ b/cartopy/docs/v0.6/examples/feature_creation.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/features.html
+++ b/cartopy/docs/v0.6/examples/features.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/global_map.html
+++ b/cartopy/docs/v0.6/examples/global_map.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/hurricane_katrina.html
+++ b/cartopy/docs/v0.6/examples/hurricane_katrina.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/logo.html
+++ b/cartopy/docs/v0.6/examples/logo.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/rotated_pole.html
+++ b/cartopy/docs/v0.6/examples/rotated_pole.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/examples/waves.html
+++ b/cartopy/docs/v0.6/examples/waves.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/gallery.html
+++ b/cartopy/docs/v0.6/gallery.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/genindex.html
+++ b/cartopy/docs/v0.6/genindex.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/index.html
+++ b/cartopy/docs/v0.6/index.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/matplotlib/advanced_plotting.html
+++ b/cartopy/docs/v0.6/matplotlib/advanced_plotting.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/matplotlib/feature_interface.html
+++ b/cartopy/docs/v0.6/matplotlib/feature_interface.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/matplotlib/geoaxes.html
+++ b/cartopy/docs/v0.6/matplotlib/geoaxes.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/matplotlib/intro.html
+++ b/cartopy/docs/v0.6/matplotlib/intro.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/projections/table.html
+++ b/cartopy/docs/v0.6/projections/table.html
@@ -32,7 +32,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/search.html
+++ b/cartopy/docs/v0.6/search.html
@@ -37,7 +37,10 @@
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/tutorials/using_the_shapereader.html
+++ b/cartopy/docs/v0.6/tutorials/using_the_shapereader.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/whats_new.html
+++ b/cartopy/docs/v0.6/whats_new.html
@@ -33,7 +33,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/cartopy/docs/v0.6/who_uses_cartopy.html
+++ b/cartopy/docs/v0.6/who_uses_cartopy.html
@@ -31,7 +31,10 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <link rel="stylesheet" href="_static/layout.css" type="text/css" />
 
-  </head>
+
+	    <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
+	    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script> 
+	  </head>
   <body>
 <!--
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">


### PR DESCRIPTION
Un-tested application of the version switcher to older documentation.
