### PR TITLE
update to link in documentation.html

### DIFF
--- a/iris/documentation.html
+++ b/iris/documentation.html
@@ -11,10 +11,13 @@
           <p>Documentation for each Iris release can be found below. The documentation contains install instructions, an in-depth userguide, a gallery of examples (with code) and a detailed set of reference documentation.</p>  
           <h2>Latest</h2>
             <ul>
-                <li><a href="docs/latest/index.html">v1.7.2</a></li>
+                <li><a href="docs/latest/index.html">v1.7.3</a></li>
             </ul>
 
           <h2>Previous releases</h2>
+            <ul>
+                <li><a href="docs/v1.7.2/index.html">v1.7.2</a></li>
+            </ul>
             <ul>
                 <li><a href="docs/v1.7/index.html">v1.7</a></li>
             </ul>


### PR DESCRIPTION
The latest docs point to v1.7.3 but the link name is still v1.7.2. This PR fixes it.
