### PR TITLE
Revert change to Cartopy docs that lost 0.13.

### DIFF
--- a/cartopy/documentation.html
+++ b/cartopy/documentation.html
@@ -48,9 +48,12 @@
           "Getting started" and some step-by-step examples.</p>
           <h2>Latest</h2>
             <ul>
-                <li><a href="docs/latest/index.html">v0.12</a></li>
+                <li><a href="docs/latest/index.html">v0.13</a></li>
             </ul>
           <h2>Previous releases</h2>
+            <ul>
+                <li><a href="docs/v0.12/index.html">v0.12</a></li>
+            </ul>
             <ul>
                 <li><a href="docs/v0.11/index.html">v0.11</a></li>
             </ul>


### PR DESCRIPTION
In #113, the link to Cartopy 0.13 was accidentally reverted.