### PR TITLE
Fix and improve the about page.

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,15 +40,13 @@
     </div>
 
     
-      <div id="bd">
-          <h1>About</h1>
-                    
-          <h2>Contributors</h2>
-            <p>Iris logo designed by richh98 (rich.hancock@ragtagdev.com)</p>
-			<div class="contributors" id="contributors"></div>
-
-			<script language="Javascript" type="text/javascript">
-				$(document).ready(function() {
+    <div id="bd">
+        <h1>About</h1>
+        <h2>Contributors</h2>
+        <p>Iris logo designed by richh98 (rich.hancock@ragtagdev.com)</p>
+        <div class="contributors" id="contributors"></div>
+            <script language="Javascript" type="text/javascript">
+                $(document).ready(function() {
                     var fjson = "contributors.json";
                     var patharray = window.location.pathname.split('/');
                     var path = "";
@@ -56,20 +54,30 @@
                         path += patharray[i] + '/';
                     }
                     var url = location.protocol + "//" + location.host + path + fjson
- 
-					// get data
-					$.getJSON(url, function(data) {
-						for (var i=0; i<data.contributors.length; i++){
-							$('#contributors').append("<p>"+data.contributors[i].profile_name+"&nbsp&nbsp&nbsp"+data.contributors[i].organisation+"<\/p>")
-						 }
-						 $('#contributors').append("<h2>Alumni</h2>");
-						for (var i=0; i<data.alumni.length; i++){
-							$('#contributors').append("<p>"+data.alumni[i].profile_name+"<\/p>")
-						 }
-						});						
-				    });		
-			</script>            
-          </div>
+                    // get data
+                    function github_url(profile_name) {
+                        return '<a href="https://github.com/' + profile_name + '">@' + profile_name + '<\/a>';
+                    }
+                    function contributor_str(contrib) {
+                        var contrib_str = github_url(contrib.profile_name);
+                        if (contrib.organisation) {
+                            contrib_str += ":&nbsp;" + contrib.organisation;
+                        }
+                        return contrib_str;
+                    }
+                    $.getJSON(url, function(data) {
+                        for (var i=0; i<data.contributors.length; i++){
+                            $('#contributors').append("<p>"+contributor_str(data.contributors[i])+"<\/p>");
+                        }
+                        $('#contributors').append("<h2>Alumni</h2>");
+                        for (var i=0; i<data.alumni.length; i++){
+                            $('#contributors').append("<p>"+contributor_str(data.alumni[i])+"<\/p>")
+                        }
+                    });
+                });
+            </script>
+        </div>
+    </div>
 
     <div id="ft">
           &copy; British Crown Copyright 2015, Met Office

--- a/contributors.json
+++ b/contributors.json
@@ -22,8 +22,7 @@
 { "profile_name":"jlstevens", "organisation":"Continuum Analytics"},
 { "profile_name":"jbednar", "organisation":"Continuum Analytics"},
 { "profile_name":"rrenfrow86", "organisation":"Continuum Analytics"},
-{ "profile_name":"Armin Leuprecht", "organisation":"Weneger Center for Climate and Global Change"},
-{ "profile_name":"Tim Michelsen", "organisation":""},
+{ "profile_name":"mir06", "organisation":"Wegener Center for Climate and Global Change"}
 ],
 "alumni": [
 { "profile_name":"dannymet97", "organisation":"West Exe Technology College"},

--- a/source/about.html
+++ b/source/about.html
@@ -8,15 +8,13 @@
 {% endblock %}
 
 {% block content %}
-      <div id="bd">
-          <h1>About</h1>
-                    
-          <h2>Contributors</h2>
-            <p>Iris logo designed by richh98 (rich.hancock@ragtagdev.com)</p>
-			<div class="contributors" id="contributors"></div>
-
-			<script language="Javascript" type="text/javascript">
-				$(document).ready(function() {
+    <div id="bd">
+        <h1>About</h1>
+        <h2>Contributors</h2>
+        <p>Iris logo designed by richh98 (rich.hancock@ragtagdev.com)</p>
+        <div class="contributors" id="contributors"></div>
+            <script language="Javascript" type="text/javascript">
+                $(document).ready(function() {
                     var fjson = "contributors.json";
                     var patharray = window.location.pathname.split('/');
                     var path = "";
@@ -24,18 +22,28 @@
                         path += patharray[i] + '/';
                     }
                     var url = location.protocol + "//" + location.host + path + fjson
- 
-					// get data
-					$.getJSON(url, function(data) {
-						for (var i=0; i<data.contributors.length; i++){
-							$('#contributors').append("<p>"+data.contributors[i].profile_name+"&nbsp&nbsp&nbsp"+data.contributors[i].organisation+"<\/p>")
-						 }
-						 $('#contributors').append("<h2>Alumni</h2>");
-						for (var i=0; i<data.alumni.length; i++){
-							$('#contributors').append("<p>"+data.alumni[i].profile_name+"<\/p>")
-						 }
-						});						
-				    });		
-			</script>            
-          </div>
+                    // get data
+                    function github_url(profile_name) {
+                        return '<a href="https://github.com/' + profile_name + '">@' + profile_name + '<\/a>';
+                    }
+                    function contributor_str(contrib) {
+                        var contrib_str = github_url(contrib.profile_name);
+                        if (contrib.organisation) {
+                            contrib_str += ":&nbsp;" + contrib.organisation;
+                        }
+                        return contrib_str;
+                    }
+                    $.getJSON(url, function(data) {
+                        for (var i=0; i<data.contributors.length; i++){
+                            $('#contributors').append("<p>"+contributor_str(data.contributors[i])+"<\/p>");
+                        }
+                        $('#contributors').append("<h2>Alumni</h2>");
+                        for (var i=0; i<data.alumni.length; i++){
+                            $('#contributors').append("<p>"+contributor_str(data.alumni[i])+"<\/p>")
+                        }
+                    });
+                });
+            </script>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Changes to fix and improve the usefulness of the about page.

##### Summary of changes:

- Malformed JSON corrected (extra comma removed).
- Name "Armin Leuprecht" changed to corresponding Github user id.
- Correct the spelling of the "Wegener Center".
- Contributor "Tim Michelsen" deleted pending identification of a Github user id.
- Profile names rendered as hyperlinks to the corresponding profile on Github.
- Cosmetic change to rendering of organisation making the entries easier to read.
- Alumni entries also render organisation name if present.

##### Tasks:

- [ ] Find the Github username of the user "Tim Michelsen", should be on the CLA document.

##### Questions:

- Is listing the organisation for Alumni desirable?
- Do we want full names included for contributors? If so I suggest we include them in brackets after the username, which should be a trivial addition of a field to the JSON and a modification of `contributor_str()`.
