### PR TITLE
Defined the SciTools steering council and its purpose

### DIFF
--- a/governance.html
+++ b/governance.html
@@ -62,7 +62,7 @@
               <ul>
                   <li>An active community contributes to the day-to-day development and upkeep of the project.</li>
                   <li>We expect the community to contribute to decisions through open debate.</li>
-                  <li>The developers will lead the project and act as final arbitrator on decisions via majority.</li>
+                  <li>The steering council will lead the project and act as final arbitrator on decisions via majority.</li>
               </ul>
           </p>
           <a id="roles"><h2>Roles and responsibilities</h2></a>
@@ -82,7 +82,7 @@
    
   <p>We will be following the 'review-then-commit' process of merging contributions into the project.</p>
    
-  <p>After nomination by, and majority backing from, the developers, major and effective contributors to the project will be invited to become a developer.</p>
+  <p>After nomination by the developers to the steering council, major and effective contributors to the project will be invited to become a developer</p>
 
           <a id="developers"><h3>Developers</h3></a>
           <p>It is the Development team's responsibility to ensure the quality of the 
@@ -97,6 +97,19 @@
 
           <a id="owners"><h3>Owners</h3></a>
           <p>Owners are responsible for the repository and for granting privileges.</p>
+
+          <a id="steering-council"><h3>Steering council</h3></a>
+          <p>The steering council is made up of a small group of long-term SciTools developers.</p>
+          <p>The council are responsible for providing high-level steer and scope for the SciTools organisation. 
+             It is also able to arbitrate decisions for the wider SciTools developer community via a simple steering council majority.</p>
+
+          <p>The steering council members are:</p>
+          <ul>
+              <li>Andrew Dawson (@ajdawson)</li>
+              <li>Bill Little (@bjlittle)</li>
+              <li>Philip Elson (@pelson)</li>
+          </ul>
+          </p>
 
           <a id="support"><h2>Support</h2></a>
           <p>Support is offered on a best endeavour only and is provided as time and resources allow. That said  

--- a/source/governance.html
+++ b/source/governance.html
@@ -30,7 +30,7 @@
               <ul>
                   <li>An active community contributes to the day-to-day development and upkeep of the project.</li>
                   <li>We expect the community to contribute to decisions through open debate.</li>
-                  <li>The developers will lead the project and act as final arbitrator on decisions via majority.</li>
+                  <li>The steering council will lead the project and act as final arbitrator on decisions via majority.</li>
               </ul>
           </p>
           <a id="roles"><h2>Roles and responsibilities</h2></a>
@@ -50,7 +50,7 @@
    
   <p>We will be following the 'review-then-commit' process of merging contributions into the project.</p>
    
-  <p>After nomination by, and majority backing from, the developers, major and effective contributors to the project will be invited to become a developer.</p>
+  <p>After nomination by the developers to the steering council, major and effective contributors to the project will be invited to become a developer</p>
 
           <a id="developers"><h3>Developers</h3></a>
           <p>It is the Development team's responsibility to ensure the quality of the 
@@ -65,6 +65,19 @@
 
           <a id="owners"><h3>Owners</h3></a>
           <p>Owners are responsible for the repository and for granting privileges.</p>
+
+          <a id="steering-council"><h3>Steering council</h3></a>
+          <p>The steering council is made up of a small group of long-term SciTools developers.</p>
+          <p>The council are responsible for providing high-level steer and scope for the SciTools organisation. 
+             It is also able to arbitrate decisions for the wider SciTools developer community via a simple steering council majority.</p>
+
+          <p>The steering council members are:</p>
+          <ul>
+              <li>Andrew Dawson (@ajdawson)</li>
+              <li>Bill Little (@bjlittle)</li>
+              <li>Philip Elson (@pelson)</li>
+          </ul>
+          </p>
 
           <a id="support"><h2>Support</h2></a>
           <p>Support is offered on a best endeavour only and is provided as time and resources allow. That said  


### PR DESCRIPTION
This PR fills in some of the gaps left by #151 by providing a steering council for decision arbitration and long-term scoping/direction. This changes the current governance model from a simple majority of developers to a simple majority of the steering-council.

Technically, in order to ratify this as the SciTools governance model we now need a majority decision from the developer community. By my reckoning there are 15 named "developers", although I believe a number of these are no-longer active (one of the major issues with the current governance model). With that in mind, I'm going to put a deadline for voting at 7 days (that is: **2017/10/24 1200 UTC**). I will cross check to ensure votes come from members of https://github.com/orgs/SciTools/teams once the deadline arrives and either merge this change (if accepted) or begin a wider consultation about how we can move forward with SciTools governance (if rejected). 

**Please vote with the 👍  👎  reactions to this description before the deadline.**

I've verified with @ajdawson and @bjlittle that they are happy to act in this role.

---

The wording is far from perfect, but I think the intent is clear. I'm 100% on board for improving the wording *once this is merged* - this will enable the steering-council to ratify any follow-on changes relatively rapidly.