### PR TITLE
Reinstate the ID that enables burger/small navigation.

### DIFF
--- a/404.html
+++ b/404.html
@@ -54,13 +54,13 @@
   <!-- START HEADER -->
   <!-- DO NOT MODIFY THIS BLOCK DIRECTLY. CHANGE index.html THEN RE-BUILD -->
   <section class="menu scitools-menu" once="menu">
-    <nav class= "navbar navbar-expand beta-menu navbar-dropdown
-            align-items-center navbar-fixed-top navbar-toggleable-sm">
+    <nav class= "navbar navbar-expand beta-menu navbar-dropdown 
+                 align-items-center navbar-fixed-top navbar-toggleable-sm">
     <button class="navbar-toggler navbar-toggler-right"
            type="button"
            data-toggle="collapse"
-           data-target="#navbarSupportedContent"
-           aria-controls="navbarSupportedContent"
+           data-target="#navbar-content"
+           aria-controls="navbar-content"
            aria-expanded="false"
            aria-label="Toggle navigation">
       <div class="hamburger">
@@ -82,7 +82,7 @@
           </span>
         </div>
       </div>
-      <div class="collapse navbar-collapse">
+      <div class="collapse navbar-collapse" id="navbar-content">
         <ul class="navbar-nav nav-dropdown nav-right"
             data-app-modern-menu="true">
           <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -47,13 +47,13 @@
 
   <!-- START HEADER -->
   <section class="menu scitools-menu" once="menu">
-    <nav class= "navbar navbar-expand beta-menu navbar-dropdown
-            align-items-center navbar-fixed-top navbar-toggleable-sm">
+    <nav class= "navbar navbar-expand beta-menu navbar-dropdown 
+                 align-items-center navbar-fixed-top navbar-toggleable-sm">
     <button class="navbar-toggler navbar-toggler-right"
            type="button"
            data-toggle="collapse"
-           data-target="#navbarSupportedContent"
-           aria-controls="navbarSupportedContent"
+           data-target="#navbar-content"
+           aria-controls="navbar-content"
            aria-expanded="false"
            aria-label="Toggle navigation">
       <div class="hamburger">
@@ -75,7 +75,7 @@
           </span>
         </div>
       </div>
-      <div class="collapse navbar-collapse">
+      <div class="collapse navbar-collapse" id="navbar-content">
         <ul class="navbar-nav nav-dropdown nav-right"
             data-app-modern-menu="true">
           <li class="nav-item">

--- a/organisation.html
+++ b/organisation.html
@@ -50,13 +50,13 @@
   <!-- START HEADER -->
   <!-- DO NOT MODIFY THIS BLOCK DIRECTLY. CHANGE index.html THEN RE-BUILD -->
   <section class="menu scitools-menu" once="menu">
-    <nav class= "navbar navbar-expand beta-menu navbar-dropdown
-            align-items-center navbar-fixed-top navbar-toggleable-sm">
+    <nav class= "navbar navbar-expand beta-menu navbar-dropdown 
+                 align-items-center navbar-fixed-top navbar-toggleable-sm">
     <button class="navbar-toggler navbar-toggler-right"
            type="button"
            data-toggle="collapse"
-           data-target="#navbarSupportedContent"
-           aria-controls="navbarSupportedContent"
+           data-target="#navbar-content"
+           aria-controls="navbar-content"
            aria-expanded="false"
            aria-label="Toggle navigation">
       <div class="hamburger">
@@ -78,7 +78,7 @@
           </span>
         </div>
       </div>
-      <div class="collapse navbar-collapse">
+      <div class="collapse navbar-collapse" id="navbar-content">
         <ul class="navbar-nav nav-dropdown nav-right"
             data-app-modern-menu="true">
           <li class="nav-item">

--- a/privacy.html
+++ b/privacy.html
@@ -50,13 +50,13 @@
   <!-- START HEADER -->
   <!-- DO NOT MODIFY THIS BLOCK DIRECTLY. CHANGE index.html THEN RE-BUILD -->
   <section class="menu scitools-menu" once="menu">
-    <nav class= "navbar navbar-expand beta-menu navbar-dropdown
-            align-items-center navbar-fixed-top navbar-toggleable-sm">
+    <nav class= "navbar navbar-expand beta-menu navbar-dropdown 
+                 align-items-center navbar-fixed-top navbar-toggleable-sm">
     <button class="navbar-toggler navbar-toggler-right"
            type="button"
            data-toggle="collapse"
-           data-target="#navbarSupportedContent"
-           aria-controls="navbarSupportedContent"
+           data-target="#navbar-content"
+           aria-controls="navbar-content"
            aria-expanded="false"
            aria-label="Toggle navigation">
       <div class="hamburger">
@@ -78,7 +78,7 @@
           </span>
         </div>
       </div>
-      <div class="collapse navbar-collapse">
+      <div class="collapse navbar-collapse" id="navbar-content">
         <ul class="navbar-nav nav-dropdown nav-right"
             data-app-modern-menu="true">
           <li class="nav-item">


### PR DESCRIPTION
Closes #195.

I knew this worked once, and assumed it had been nuked at some point with css/html tidying. The commit I found to be working was ab9c23b7 (I didn't bisect, so there may have been other commits that worked too), and saw that the important ID had been removed.