### PR TITLE
http -> https for copybutton.js

### DIFF
--- a/iris/docs/v1.10.0/contents.html
+++ b/iris/docs/v1.10.0/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/copyright.html
+++ b/iris/docs/v1.10.0/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/deprecations.html
+++ b/iris/docs/v1.10.0/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.10.0/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/documenting/index.html
+++ b/iris/docs/v1.10.0/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.10.0/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.10.0/developers_guide/documenting/whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.10.0/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/index.html
+++ b/iris/docs/v1.10.0/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/pulls.html
+++ b/iris/docs/v1.10.0/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/release.html
+++ b/iris/docs/v1.10.0/developers_guide/release.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/developers_guide/tests.html
+++ b/iris/docs/v1.10.0/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.10.0/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.10.0/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/coriolis_plot.html
+++ b/iris/docs/v1.10.0/examples/General/coriolis_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/cross_section.html
+++ b/iris/docs/v1.10.0/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.10.0/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.10.0/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/global_map.html
+++ b/iris/docs/v1.10.0/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/index.html
+++ b/iris/docs/v1.10.0/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/inset_plot.html
+++ b/iris/docs/v1.10.0/examples/General/inset_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.10.0/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/orca_projection.html
+++ b/iris/docs/v1.10.0/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/polar_stereo.html
+++ b/iris/docs/v1.10.0/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.10.0/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.10.0/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.10.0/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/index.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v1.10.0/examples/Meteorology/wind_speed.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.10.0/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/Oceanography/index.html
+++ b/iris/docs/v1.10.0/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/examples/index.html
+++ b/iris/docs/v1.10.0/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/gallery.html
+++ b/iris/docs/v1.10.0/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/genindex.html
+++ b/iris/docs/v1.10.0/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/installing.html
+++ b/iris/docs/v1.10.0/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris.html
+++ b/iris/docs/v1.10.0/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.10.0/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/aux_factory.html
+++ b/iris/docs/v1.10.0/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/config.html
+++ b/iris/docs/v1.10.0/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.10.0/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/coord_systems.html
+++ b/iris/docs/v1.10.0/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/coords.html
+++ b/iris/docs/v1.10.0/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/cube.html
+++ b/iris/docs/v1.10.0/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/exceptions.html
+++ b/iris/docs/v1.10.0/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/experimental/um.html
+++ b/iris/docs/v1.10.0/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/grib/message.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/grib/message.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.10.0/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/io.html
+++ b/iris/docs/v1.10.0/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.10.0/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/iterate.html
+++ b/iris/docs/v1.10.0/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/palette.html
+++ b/iris/docs/v1.10.0/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/pandas.html
+++ b/iris/docs/v1.10.0/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/plot.html
+++ b/iris/docs/v1.10.0/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/proxy.html
+++ b/iris/docs/v1.10.0/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/quickplot.html
+++ b/iris/docs/v1.10.0/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/std_names.html
+++ b/iris/docs/v1.10.0/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/symbols.html
+++ b/iris/docs/v1.10.0/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/time.html
+++ b/iris/docs/v1.10.0/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/unit.html
+++ b/iris/docs/v1.10.0/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/iris/iris/util.html
+++ b/iris/docs/v1.10.0/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/search.html
+++ b/iris/docs/v1.10.0/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.10.0/userguide/citation.html
+++ b/iris/docs/v1.10.0/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/code_maintenance.html
+++ b/iris/docs/v1.10.0/userguide/code_maintenance.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/cube_maths.html
+++ b/iris/docs/v1.10.0/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/cube_statistics.html
+++ b/iris/docs/v1.10.0/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/end_of_userguide.html
+++ b/iris/docs/v1.10.0/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/index.html
+++ b/iris/docs/v1.10.0/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.10.0/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/iris_cubes.html
+++ b/iris/docs/v1.10.0/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.10.0/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/merge_and_concat.html
+++ b/iris/docs/v1.10.0/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.10.0/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.10.0/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.10.0/userguide/saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.10.0/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.0.html
+++ b/iris/docs/v1.10.0/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.1.html
+++ b/iris/docs/v1.10.0/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.10.html
+++ b/iris/docs/v1.10.0/whatsnew/1.10.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.2.html
+++ b/iris/docs/v1.10.0/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.3.html
+++ b/iris/docs/v1.10.0/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.4.html
+++ b/iris/docs/v1.10.0/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.5.html
+++ b/iris/docs/v1.10.0/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.6.html
+++ b/iris/docs/v1.10.0/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.7.html
+++ b/iris/docs/v1.10.0/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.8.html
+++ b/iris/docs/v1.10.0/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/1.9.html
+++ b/iris/docs/v1.10.0/whatsnew/1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whatsnew/index.html
+++ b/iris/docs/v1.10.0/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whitepapers/change_management.html
+++ b/iris/docs/v1.10.0/whitepapers/change_management.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whitepapers/index.html
+++ b/iris/docs/v1.10.0/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.10.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.10.0/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/contents.html
+++ b/iris/docs/v1.11.0/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/copyright.html
+++ b/iris/docs/v1.11.0/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/deprecations.html
+++ b/iris/docs/v1.11.0/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.11.0/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/documenting/index.html
+++ b/iris/docs/v1.11.0/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.11.0/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.11.0/developers_guide/documenting/whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.11.0/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/index.html
+++ b/iris/docs/v1.11.0/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/pulls.html
+++ b/iris/docs/v1.11.0/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/release.html
+++ b/iris/docs/v1.11.0/developers_guide/release.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/developers_guide/tests.html
+++ b/iris/docs/v1.11.0/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.11.0/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.11.0/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/coriolis_plot.html
+++ b/iris/docs/v1.11.0/examples/General/coriolis_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/cross_section.html
+++ b/iris/docs/v1.11.0/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.11.0/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.11.0/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/global_map.html
+++ b/iris/docs/v1.11.0/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/index.html
+++ b/iris/docs/v1.11.0/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/inset_plot.html
+++ b/iris/docs/v1.11.0/examples/General/inset_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.11.0/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/orca_projection.html
+++ b/iris/docs/v1.11.0/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/polar_stereo.html
+++ b/iris/docs/v1.11.0/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.11.0/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.11.0/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.11.0/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/index.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v1.11.0/examples/Meteorology/wind_speed.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.11.0/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/Oceanography/index.html
+++ b/iris/docs/v1.11.0/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/examples/index.html
+++ b/iris/docs/v1.11.0/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/gallery.html
+++ b/iris/docs/v1.11.0/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/genindex.html
+++ b/iris/docs/v1.11.0/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/installing.html
+++ b/iris/docs/v1.11.0/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris.html
+++ b/iris/docs/v1.11.0/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.11.0/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/aux_factory.html
+++ b/iris/docs/v1.11.0/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/config.html
+++ b/iris/docs/v1.11.0/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.11.0/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/coord_systems.html
+++ b/iris/docs/v1.11.0/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/coords.html
+++ b/iris/docs/v1.11.0/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/cube.html
+++ b/iris/docs/v1.11.0/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/exceptions.html
+++ b/iris/docs/v1.11.0/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/experimental/um.html
+++ b/iris/docs/v1.11.0/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/grib/message.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/grib/message.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.11.0/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/io.html
+++ b/iris/docs/v1.11.0/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.11.0/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/iterate.html
+++ b/iris/docs/v1.11.0/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/palette.html
+++ b/iris/docs/v1.11.0/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/pandas.html
+++ b/iris/docs/v1.11.0/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/plot.html
+++ b/iris/docs/v1.11.0/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/proxy.html
+++ b/iris/docs/v1.11.0/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/quickplot.html
+++ b/iris/docs/v1.11.0/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/std_names.html
+++ b/iris/docs/v1.11.0/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/symbols.html
+++ b/iris/docs/v1.11.0/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/time.html
+++ b/iris/docs/v1.11.0/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/unit.html
+++ b/iris/docs/v1.11.0/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/iris/iris/util.html
+++ b/iris/docs/v1.11.0/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/search.html
+++ b/iris/docs/v1.11.0/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.11.0/userguide/citation.html
+++ b/iris/docs/v1.11.0/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/code_maintenance.html
+++ b/iris/docs/v1.11.0/userguide/code_maintenance.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/cube_maths.html
+++ b/iris/docs/v1.11.0/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/cube_statistics.html
+++ b/iris/docs/v1.11.0/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/end_of_userguide.html
+++ b/iris/docs/v1.11.0/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/index.html
+++ b/iris/docs/v1.11.0/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.11.0/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/iris_cubes.html
+++ b/iris/docs/v1.11.0/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.11.0/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/merge_and_concat.html
+++ b/iris/docs/v1.11.0/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.11.0/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.11.0/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.11.0/userguide/saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.11.0/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.0.html
+++ b/iris/docs/v1.11.0/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.1.html
+++ b/iris/docs/v1.11.0/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.10.html
+++ b/iris/docs/v1.11.0/whatsnew/1.10.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.11.html
+++ b/iris/docs/v1.11.0/whatsnew/1.11.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.2.html
+++ b/iris/docs/v1.11.0/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.3.html
+++ b/iris/docs/v1.11.0/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.4.html
+++ b/iris/docs/v1.11.0/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.5.html
+++ b/iris/docs/v1.11.0/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.6.html
+++ b/iris/docs/v1.11.0/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.7.html
+++ b/iris/docs/v1.11.0/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.8.html
+++ b/iris/docs/v1.11.0/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/1.9.html
+++ b/iris/docs/v1.11.0/whatsnew/1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whatsnew/index.html
+++ b/iris/docs/v1.11.0/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whitepapers/change_management.html
+++ b/iris/docs/v1.11.0/whitepapers/change_management.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whitepapers/index.html
+++ b/iris/docs/v1.11.0/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.11.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.11.0/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/contents.html
+++ b/iris/docs/v1.12.0/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/copyright.html
+++ b/iris/docs/v1.12.0/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/deprecations.html
+++ b/iris/docs/v1.12.0/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.12.0/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/documenting/index.html
+++ b/iris/docs/v1.12.0/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.12.0/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.12.0/developers_guide/documenting/whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.12.0/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/graphics_tests.html
+++ b/iris/docs/v1.12.0/developers_guide/graphics_tests.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/index.html
+++ b/iris/docs/v1.12.0/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/pulls.html
+++ b/iris/docs/v1.12.0/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/release.html
+++ b/iris/docs/v1.12.0/developers_guide/release.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/developers_guide/tests.html
+++ b/iris/docs/v1.12.0/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.12.0/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.12.0/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/coriolis_plot.html
+++ b/iris/docs/v1.12.0/examples/General/coriolis_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/cross_section.html
+++ b/iris/docs/v1.12.0/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.12.0/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.12.0/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/global_map.html
+++ b/iris/docs/v1.12.0/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/index.html
+++ b/iris/docs/v1.12.0/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/inset_plot.html
+++ b/iris/docs/v1.12.0/examples/General/inset_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.12.0/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/orca_projection.html
+++ b/iris/docs/v1.12.0/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/polar_stereo.html
+++ b/iris/docs/v1.12.0/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.12.0/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.12.0/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.12.0/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/index.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v1.12.0/examples/Meteorology/wind_speed.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.12.0/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/Oceanography/index.html
+++ b/iris/docs/v1.12.0/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/examples/index.html
+++ b/iris/docs/v1.12.0/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/gallery.html
+++ b/iris/docs/v1.12.0/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/genindex.html
+++ b/iris/docs/v1.12.0/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/installing.html
+++ b/iris/docs/v1.12.0/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris.html
+++ b/iris/docs/v1.12.0/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.12.0/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/aux_factory.html
+++ b/iris/docs/v1.12.0/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/config.html
+++ b/iris/docs/v1.12.0/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.12.0/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/coord_systems.html
+++ b/iris/docs/v1.12.0/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/coords.html
+++ b/iris/docs/v1.12.0/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/cube.html
+++ b/iris/docs/v1.12.0/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/exceptions.html
+++ b/iris/docs/v1.12.0/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/experimental/um.html
+++ b/iris/docs/v1.12.0/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/grib/message.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/grib/message.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.12.0/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/io.html
+++ b/iris/docs/v1.12.0/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.12.0/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/iterate.html
+++ b/iris/docs/v1.12.0/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/palette.html
+++ b/iris/docs/v1.12.0/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/pandas.html
+++ b/iris/docs/v1.12.0/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/plot.html
+++ b/iris/docs/v1.12.0/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/proxy.html
+++ b/iris/docs/v1.12.0/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/quickplot.html
+++ b/iris/docs/v1.12.0/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/std_names.html
+++ b/iris/docs/v1.12.0/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/symbols.html
+++ b/iris/docs/v1.12.0/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/time.html
+++ b/iris/docs/v1.12.0/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/unit.html
+++ b/iris/docs/v1.12.0/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/iris/iris/util.html
+++ b/iris/docs/v1.12.0/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/search.html
+++ b/iris/docs/v1.12.0/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.12.0/userguide/citation.html
+++ b/iris/docs/v1.12.0/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/code_maintenance.html
+++ b/iris/docs/v1.12.0/userguide/code_maintenance.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/cube_maths.html
+++ b/iris/docs/v1.12.0/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/cube_statistics.html
+++ b/iris/docs/v1.12.0/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/end_of_userguide.html
+++ b/iris/docs/v1.12.0/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/index.html
+++ b/iris/docs/v1.12.0/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.12.0/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/iris_cubes.html
+++ b/iris/docs/v1.12.0/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.12.0/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/merge_and_concat.html
+++ b/iris/docs/v1.12.0/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.12.0/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.12.0/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.12.0/userguide/saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.12.0/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.0.html
+++ b/iris/docs/v1.12.0/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.1.html
+++ b/iris/docs/v1.12.0/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.10.html
+++ b/iris/docs/v1.12.0/whatsnew/1.10.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.11.html
+++ b/iris/docs/v1.12.0/whatsnew/1.11.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.12.html
+++ b/iris/docs/v1.12.0/whatsnew/1.12.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.2.html
+++ b/iris/docs/v1.12.0/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.3.html
+++ b/iris/docs/v1.12.0/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.4.html
+++ b/iris/docs/v1.12.0/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.5.html
+++ b/iris/docs/v1.12.0/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.6.html
+++ b/iris/docs/v1.12.0/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.7.html
+++ b/iris/docs/v1.12.0/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.8.html
+++ b/iris/docs/v1.12.0/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/1.9.html
+++ b/iris/docs/v1.12.0/whatsnew/1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whatsnew/index.html
+++ b/iris/docs/v1.12.0/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whitepapers/change_management.html
+++ b/iris/docs/v1.12.0/whitepapers/change_management.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whitepapers/index.html
+++ b/iris/docs/v1.12.0/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.12.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.12.0/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.13.0/contents.html
+++ b/iris/docs/v1.13.0/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/copyright.html
+++ b/iris/docs/v1.13.0/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/deprecations.html
+++ b/iris/docs/v1.13.0/developers_guide/deprecations.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.13.0/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/documenting/index.html
+++ b/iris/docs/v1.13.0/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.13.0/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.13.0/developers_guide/documenting/whats_new_contributions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.13.0/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/graphics_tests.html
+++ b/iris/docs/v1.13.0/developers_guide/graphics_tests.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/index.html
+++ b/iris/docs/v1.13.0/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/pulls.html
+++ b/iris/docs/v1.13.0/developers_guide/pulls.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/release.html
+++ b/iris/docs/v1.13.0/developers_guide/release.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/developers_guide/tests.html
+++ b/iris/docs/v1.13.0/developers_guide/tests.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.13.0/examples/General/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.13.0/examples/General/anomaly_log_colouring.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/coriolis_plot.html
+++ b/iris/docs/v1.13.0/examples/General/coriolis_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/cross_section.html
+++ b/iris/docs/v1.13.0/examples/General/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.13.0/examples/General/custom_aggregation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.13.0/examples/General/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/global_map.html
+++ b/iris/docs/v1.13.0/examples/General/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/index.html
+++ b/iris/docs/v1.13.0/examples/General/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/inset_plot.html
+++ b/iris/docs/v1.13.0/examples/General/inset_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.13.0/examples/General/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/orca_projection.html
+++ b/iris/docs/v1.13.0/examples/General/orca_projection.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/polar_stereo.html
+++ b/iris/docs/v1.13.0/examples/General/polar_stereo.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.13.0/examples/General/polynomial_fit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.13.0/examples/General/projections_and_annotations.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.13.0/examples/General/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/index.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v1.13.0/examples/Meteorology/wind_speed.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.13.0/examples/Oceanography/atlantic_profiles.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/Oceanography/index.html
+++ b/iris/docs/v1.13.0/examples/Oceanography/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/examples/index.html
+++ b/iris/docs/v1.13.0/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/gallery.html
+++ b/iris/docs/v1.13.0/gallery.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/genindex.html
+++ b/iris/docs/v1.13.0/genindex.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/installing.html
+++ b/iris/docs/v1.13.0/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris.html
+++ b/iris/docs/v1.13.0/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/TEST.html
+++ b/iris/docs/v1.13.0/iris/iris/TEST.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/stats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.13.0/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/aux_factory.html
+++ b/iris/docs/v1.13.0/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/config.html
+++ b/iris/docs/v1.13.0/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.13.0/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/coord_systems.html
+++ b/iris/docs/v1.13.0/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/coords.html
+++ b/iris/docs/v1.13.0/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/cube.html
+++ b/iris/docs/v1.13.0/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/exceptions.html
+++ b/iris/docs/v1.13.0/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/animate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/equalise_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/fieldsfile.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/stratify.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/stratify.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/ugrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/experimental/um.html
+++ b/iris/docs/v1.13.0/iris/iris/experimental/um.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/grib/load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/grib/message.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/grib/message.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/name.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/name_loaders.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/pp_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/um.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.13.0/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/io.html
+++ b/iris/docs/v1.13.0/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.13.0/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/iterate.html
+++ b/iris/docs/v1.13.0/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/palette.html
+++ b/iris/docs/v1.13.0/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/pandas.html
+++ b/iris/docs/v1.13.0/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/plot.html
+++ b/iris/docs/v1.13.0/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/proxy.html
+++ b/iris/docs/v1.13.0/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/quickplot.html
+++ b/iris/docs/v1.13.0/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/std_names.html
+++ b/iris/docs/v1.13.0/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/symbols.html
+++ b/iris/docs/v1.13.0/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/time.html
+++ b/iris/docs/v1.13.0/iris/iris/time.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/unit.html
+++ b/iris/docs/v1.13.0/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/iris/iris/util.html
+++ b/iris/docs/v1.13.0/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/search.html
+++ b/iris/docs/v1.13.0/search.html
@@ -39,7 +39,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.13.0/userguide/citation.html
+++ b/iris/docs/v1.13.0/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/code_maintenance.html
+++ b/iris/docs/v1.13.0/userguide/code_maintenance.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/cube_maths.html
+++ b/iris/docs/v1.13.0/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/cube_statistics.html
+++ b/iris/docs/v1.13.0/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/end_of_userguide.html
+++ b/iris/docs/v1.13.0/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/index.html
+++ b/iris/docs/v1.13.0/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.13.0/userguide/interpolation_and_regridding.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/iris_cubes.html
+++ b/iris/docs/v1.13.0/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.13.0/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/merge_and_concat.html
+++ b/iris/docs/v1.13.0/userguide/merge_and_concat.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.13.0/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.13.0/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.13.0/userguide/saving_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.13.0/userguide/subsetting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.0.html
+++ b/iris/docs/v1.13.0/whatsnew/1.0.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.1.html
+++ b/iris/docs/v1.13.0/whatsnew/1.1.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.10.html
+++ b/iris/docs/v1.13.0/whatsnew/1.10.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.11.html
+++ b/iris/docs/v1.13.0/whatsnew/1.11.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.12.html
+++ b/iris/docs/v1.13.0/whatsnew/1.12.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.13.html
+++ b/iris/docs/v1.13.0/whatsnew/1.13.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.2.html
+++ b/iris/docs/v1.13.0/whatsnew/1.2.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.3.html
+++ b/iris/docs/v1.13.0/whatsnew/1.3.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.4.html
+++ b/iris/docs/v1.13.0/whatsnew/1.4.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.5.html
+++ b/iris/docs/v1.13.0/whatsnew/1.5.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.6.html
+++ b/iris/docs/v1.13.0/whatsnew/1.6.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.7.html
+++ b/iris/docs/v1.13.0/whatsnew/1.7.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.8.html
+++ b/iris/docs/v1.13.0/whatsnew/1.8.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/1.9.html
+++ b/iris/docs/v1.13.0/whatsnew/1.9.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whatsnew/index.html
+++ b/iris/docs/v1.13.0/whatsnew/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whitepapers/change_management.html
+++ b/iris/docs/v1.13.0/whitepapers/change_management.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whitepapers/index.html
+++ b/iris/docs/v1.13.0/whitepapers/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.13.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.13.0/whitepapers/um_files_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body role="document">

--- a/iris/docs/v1.3/contents.html
+++ b/iris/docs/v1.3/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/copyright.html
+++ b/iris/docs/v1.3/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.3/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/documenting/index.html
+++ b/iris/docs/v1.3/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.3/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.3/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/developers_guide/index.html
+++ b/iris/docs/v1.3/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.3/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.3/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.3/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/TEC.html
+++ b/iris/docs/v1.3/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/cross_section.html
+++ b/iris/docs/v1.3/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.3/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.3/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/global_map.html
+++ b/iris/docs/v1.3/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.3/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/index.html
+++ b/iris/docs/v1.3/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.3/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.3/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.3/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/examples/index.html
+++ b/iris/docs/v1.3/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/gallery.html
+++ b/iris/docs/v1.3/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/genindex.html
+++ b/iris/docs/v1.3/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/installing.html
+++ b/iris/docs/v1.3/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris.html
+++ b/iris/docs/v1.3/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis.html
+++ b/iris/docs/v1.3/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.3/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.3/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.3/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.3/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.3/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.3/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/aux_factory.html
+++ b/iris/docs/v1.3/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/config.html
+++ b/iris/docs/v1.3/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.3/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/coord_systems.html
+++ b/iris/docs/v1.3/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/coords.html
+++ b/iris/docs/v1.3/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/cube.html
+++ b/iris/docs/v1.3/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/exceptions.html
+++ b/iris/docs/v1.3/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/experimental.html
+++ b/iris/docs/v1.3/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.3/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.3/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/experimental/fileformats/abf.html
+++ b/iris/docs/v1.3/iris/iris/experimental/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats.html
+++ b/iris/docs/v1.3/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/grib_save_rules.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/manager.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/manager.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/mosig_cf_map.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/mosig_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.3/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/io.html
+++ b/iris/docs/v1.3/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.3/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/iterate.html
+++ b/iris/docs/v1.3/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/palette.html
+++ b/iris/docs/v1.3/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/plot.html
+++ b/iris/docs/v1.3/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/proxy.html
+++ b/iris/docs/v1.3/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/quickplot.html
+++ b/iris/docs/v1.3/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/std_names.html
+++ b/iris/docs/v1.3/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/symbols.html
+++ b/iris/docs/v1.3/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/unit.html
+++ b/iris/docs/v1.3/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/iris/iris/util.html
+++ b/iris/docs/v1.3/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/search.html
+++ b/iris/docs/v1.3/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.3/userguide/citation.html
+++ b/iris/docs/v1.3/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/cube_maths.html
+++ b/iris/docs/v1.3/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/cube_statistics.html
+++ b/iris/docs/v1.3/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/end_of_userguide.html
+++ b/iris/docs/v1.3/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/index.html
+++ b/iris/docs/v1.3/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/iris_cubes.html
+++ b/iris/docs/v1.3/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.3/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.3/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.3/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/userguide/reducing_a_cube.html
+++ b/iris/docs/v1.3/userguide/reducing_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/whatsnew/1.0.html
+++ b/iris/docs/v1.3/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/whatsnew/1.1.html
+++ b/iris/docs/v1.3/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/whatsnew/1.2.html
+++ b/iris/docs/v1.3/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/whatsnew/1.3.html
+++ b/iris/docs/v1.3/whatsnew/1.3.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.3/whatsnew/index.html
+++ b/iris/docs/v1.3/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/contents.html
+++ b/iris/docs/v1.4/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/copyright.html
+++ b/iris/docs/v1.4/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.4/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/documenting/index.html
+++ b/iris/docs/v1.4/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.4/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.4/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/developers_guide/index.html
+++ b/iris/docs/v1.4/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.4/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.4/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.4/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/TEC.html
+++ b/iris/docs/v1.4/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/cross_section.html
+++ b/iris/docs/v1.4/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.4/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.4/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/global_map.html
+++ b/iris/docs/v1.4/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.4/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/index.html
+++ b/iris/docs/v1.4/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.4/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.4/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.4/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/examples/index.html
+++ b/iris/docs/v1.4/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/gallery.html
+++ b/iris/docs/v1.4/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/genindex.html
+++ b/iris/docs/v1.4/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/installing.html
+++ b/iris/docs/v1.4/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris.html
+++ b/iris/docs/v1.4/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis.html
+++ b/iris/docs/v1.4/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.4/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.4/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.4/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.4/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.4/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.4/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/aux_factory.html
+++ b/iris/docs/v1.4/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/config.html
+++ b/iris/docs/v1.4/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.4/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/coord_systems.html
+++ b/iris/docs/v1.4/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/coords.html
+++ b/iris/docs/v1.4/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/cube.html
+++ b/iris/docs/v1.4/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/exceptions.html
+++ b/iris/docs/v1.4/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental.html
+++ b/iris/docs/v1.4/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.4/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.4/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/fileformats/abf.html
+++ b/iris/docs/v1.4/iris/iris/experimental/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.4/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.4/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.4/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats.html
+++ b/iris/docs/v1.4/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/manager.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/manager.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/mosig_cf_map.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/mosig_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.4/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/io.html
+++ b/iris/docs/v1.4/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.4/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/iterate.html
+++ b/iris/docs/v1.4/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/palette.html
+++ b/iris/docs/v1.4/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/pandas.html
+++ b/iris/docs/v1.4/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/plot.html
+++ b/iris/docs/v1.4/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/proxy.html
+++ b/iris/docs/v1.4/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/quickplot.html
+++ b/iris/docs/v1.4/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/std_names.html
+++ b/iris/docs/v1.4/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/symbols.html
+++ b/iris/docs/v1.4/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/unit.html
+++ b/iris/docs/v1.4/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/iris/iris/util.html
+++ b/iris/docs/v1.4/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/search.html
+++ b/iris/docs/v1.4/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.4/userguide/citation.html
+++ b/iris/docs/v1.4/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/cube_maths.html
+++ b/iris/docs/v1.4/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/cube_statistics.html
+++ b/iris/docs/v1.4/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/end_of_userguide.html
+++ b/iris/docs/v1.4/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/index.html
+++ b/iris/docs/v1.4/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/iris_cubes.html
+++ b/iris/docs/v1.4/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.4/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.4/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.4/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/userguide/reducing_a_cube.html
+++ b/iris/docs/v1.4/userguide/reducing_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/1.0.html
+++ b/iris/docs/v1.4/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/1.1.html
+++ b/iris/docs/v1.4/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/1.2.html
+++ b/iris/docs/v1.4/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/1.3.html
+++ b/iris/docs/v1.4/whatsnew/1.3.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/1.4.html
+++ b/iris/docs/v1.4/whatsnew/1.4.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.4/whatsnew/index.html
+++ b/iris/docs/v1.4/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/contents.html
+++ b/iris/docs/v1.5/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/copyright.html
+++ b/iris/docs/v1.5/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.5/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/documenting/index.html
+++ b/iris/docs/v1.5/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.5/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.5/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/developers_guide/index.html
+++ b/iris/docs/v1.5/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.5/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.5/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.5/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/TEC.html
+++ b/iris/docs/v1.5/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/atlantic_profiles.html
+++ b/iris/docs/v1.5/examples/graphics/atlantic_profiles.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/cross_section.html
+++ b/iris/docs/v1.5/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.5/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.5/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/global_map.html
+++ b/iris/docs/v1.5/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.5/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/index.html
+++ b/iris/docs/v1.5/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.5/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.5/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/polar_stereo.html
+++ b/iris/docs/v1.5/examples/graphics/polar_stereo.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.5/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/examples/index.html
+++ b/iris/docs/v1.5/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/gallery.html
+++ b/iris/docs/v1.5/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/genindex.html
+++ b/iris/docs/v1.5/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/installing.html
+++ b/iris/docs/v1.5/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris.html
+++ b/iris/docs/v1.5/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis.html
+++ b/iris/docs/v1.5/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.5/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.5/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.5/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.5/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.5/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.5/iris/iris/analysis/stats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.5/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/aux_factory.html
+++ b/iris/docs/v1.5/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/config.html
+++ b/iris/docs/v1.5/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.5/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/coord_systems.html
+++ b/iris/docs/v1.5/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/coords.html
+++ b/iris/docs/v1.5/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/cube.html
+++ b/iris/docs/v1.5/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/exceptions.html
+++ b/iris/docs/v1.5/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental.html
+++ b/iris/docs/v1.5/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.5/iris/iris/experimental/animate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.5/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.5/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/fileformats/abf.html
+++ b/iris/docs/v1.5/iris/iris/experimental/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.5/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.5/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.5/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats.html
+++ b/iris/docs/v1.5/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/grib/load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/manager.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/manager.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/mosig_cf_map.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/mosig_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/name.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/name_loaders.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/pp_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.5/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/io.html
+++ b/iris/docs/v1.5/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.5/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/iterate.html
+++ b/iris/docs/v1.5/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/palette.html
+++ b/iris/docs/v1.5/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/pandas.html
+++ b/iris/docs/v1.5/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/plot.html
+++ b/iris/docs/v1.5/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/proxy.html
+++ b/iris/docs/v1.5/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/quickplot.html
+++ b/iris/docs/v1.5/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/std_names.html
+++ b/iris/docs/v1.5/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/symbols.html
+++ b/iris/docs/v1.5/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/unit.html
+++ b/iris/docs/v1.5/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/iris/iris/util.html
+++ b/iris/docs/v1.5/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/search.html
+++ b/iris/docs/v1.5/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.5/userguide/citation.html
+++ b/iris/docs/v1.5/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/cube_maths.html
+++ b/iris/docs/v1.5/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/cube_statistics.html
+++ b/iris/docs/v1.5/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/end_of_userguide.html
+++ b/iris/docs/v1.5/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/index.html
+++ b/iris/docs/v1.5/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/iris_cubes.html
+++ b/iris/docs/v1.5/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.5/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.5/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.5/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/userguide/reducing_a_cube.html
+++ b/iris/docs/v1.5/userguide/reducing_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.0.html
+++ b/iris/docs/v1.5/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.1.html
+++ b/iris/docs/v1.5/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.2.html
+++ b/iris/docs/v1.5/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.3.html
+++ b/iris/docs/v1.5/whatsnew/1.3.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.4.html
+++ b/iris/docs/v1.5/whatsnew/1.4.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/1.5.html
+++ b/iris/docs/v1.5/whatsnew/1.5.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.5/whatsnew/index.html
+++ b/iris/docs/v1.5/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/contents.html
+++ b/iris/docs/v1.6/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/copyright.html
+++ b/iris/docs/v1.6/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.6/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/documenting/index.html
+++ b/iris/docs/v1.6/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.6/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.6/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/index.html
+++ b/iris/docs/v1.6/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/pulls.html
+++ b/iris/docs/v1.6/developers_guide/pulls.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/developers_guide/tests.html
+++ b/iris/docs/v1.6/developers_guide/tests.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.6/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.6/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.6/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/TEC.html
+++ b/iris/docs/v1.6/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/atlantic_profiles.html
+++ b/iris/docs/v1.6/examples/graphics/atlantic_profiles.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/cross_section.html
+++ b/iris/docs/v1.6/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.6/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.6/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/global_map.html
+++ b/iris/docs/v1.6/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.6/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/index.html
+++ b/iris/docs/v1.6/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.6/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.6/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/polar_stereo.html
+++ b/iris/docs/v1.6/examples/graphics/polar_stereo.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.6/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/examples/index.html
+++ b/iris/docs/v1.6/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/gallery.html
+++ b/iris/docs/v1.6/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/genindex.html
+++ b/iris/docs/v1.6/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/installing.html
+++ b/iris/docs/v1.6/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris.html
+++ b/iris/docs/v1.6/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis.html
+++ b/iris/docs/v1.6/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.6/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.6/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.6/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.6/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.6/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.6/iris/iris/analysis/stats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.6/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/aux_factory.html
+++ b/iris/docs/v1.6/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/config.html
+++ b/iris/docs/v1.6/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.6/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/coord_systems.html
+++ b/iris/docs/v1.6/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/coords.html
+++ b/iris/docs/v1.6/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/cube.html
+++ b/iris/docs/v1.6/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/exceptions.html
+++ b/iris/docs/v1.6/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental.html
+++ b/iris/docs/v1.6/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.6/iris/iris/experimental/animate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.6/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.6/iris/iris/experimental/equalise_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.6/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.6/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.6/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.6/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats.html
+++ b/iris/docs/v1.6/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/grib/load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/manager.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/manager.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/name.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/name_loaders.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/pp_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.6/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/io.html
+++ b/iris/docs/v1.6/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.6/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/iterate.html
+++ b/iris/docs/v1.6/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/palette.html
+++ b/iris/docs/v1.6/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/pandas.html
+++ b/iris/docs/v1.6/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/plot.html
+++ b/iris/docs/v1.6/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/proxy.html
+++ b/iris/docs/v1.6/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/quickplot.html
+++ b/iris/docs/v1.6/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/std_names.html
+++ b/iris/docs/v1.6/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/symbols.html
+++ b/iris/docs/v1.6/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/time.html
+++ b/iris/docs/v1.6/iris/iris/time.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/unit.html
+++ b/iris/docs/v1.6/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/iris/iris/util.html
+++ b/iris/docs/v1.6/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/search.html
+++ b/iris/docs/v1.6/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.6/userguide/citation.html
+++ b/iris/docs/v1.6/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/cube_maths.html
+++ b/iris/docs/v1.6/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/cube_statistics.html
+++ b/iris/docs/v1.6/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/end_of_userguide.html
+++ b/iris/docs/v1.6/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/index.html
+++ b/iris/docs/v1.6/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/iris_cubes.html
+++ b/iris/docs/v1.6/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.6/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.6/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.6/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/userguide/reducing_a_cube.html
+++ b/iris/docs/v1.6/userguide/reducing_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.0.html
+++ b/iris/docs/v1.6/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.1.html
+++ b/iris/docs/v1.6/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.2.html
+++ b/iris/docs/v1.6/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.3.html
+++ b/iris/docs/v1.6/whatsnew/1.3.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.4.html
+++ b/iris/docs/v1.6/whatsnew/1.4.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.5.html
+++ b/iris/docs/v1.6/whatsnew/1.5.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/1.6.html
+++ b/iris/docs/v1.6/whatsnew/1.6.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.6/whatsnew/index.html
+++ b/iris/docs/v1.6/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/contents.html
+++ b/iris/docs/v1.7.2/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/copyright.html
+++ b/iris/docs/v1.7.2/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.7.2/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/documenting/index.html
+++ b/iris/docs/v1.7.2/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.7.2/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.7.2/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/index.html
+++ b/iris/docs/v1.7.2/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/pulls.html
+++ b/iris/docs/v1.7.2/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/developers_guide/tests.html
+++ b/iris/docs/v1.7.2/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.7.2/examples/graphics/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.7.2/examples/graphics/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.7.2/examples/graphics/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/TEC.html
+++ b/iris/docs/v1.7.2/examples/graphics/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/anomaly_log_colouring.html
+++ b/iris/docs/v1.7.2/examples/graphics/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/atlantic_profiles.html
+++ b/iris/docs/v1.7.2/examples/graphics/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/cross_section.html
+++ b/iris/docs/v1.7.2/examples/graphics/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/custom_aggregation.html
+++ b/iris/docs/v1.7.2/examples/graphics/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.7.2/examples/graphics/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.7.2/examples/graphics/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/global_map.html
+++ b/iris/docs/v1.7.2/examples/graphics/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.7.2/examples/graphics/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/index.html
+++ b/iris/docs/v1.7.2/examples/graphics/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.7.2/examples/graphics/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.7.2/examples/graphics/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/orca_projection.html
+++ b/iris/docs/v1.7.2/examples/graphics/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/polar_stereo.html
+++ b/iris/docs/v1.7.2/examples/graphics/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/projections_and_annotations.html
+++ b/iris/docs/v1.7.2/examples/graphics/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.7.2/examples/graphics/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/examples/index.html
+++ b/iris/docs/v1.7.2/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/gallery.html
+++ b/iris/docs/v1.7.2/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/genindex.html
+++ b/iris/docs/v1.7.2/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/installing.html
+++ b/iris/docs/v1.7.2/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris.html
+++ b/iris/docs/v1.7.2/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.7.2/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/aux_factory.html
+++ b/iris/docs/v1.7.2/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/config.html
+++ b/iris/docs/v1.7.2/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.7.2/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/coord_systems.html
+++ b/iris/docs/v1.7.2/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/coords.html
+++ b/iris/docs/v1.7.2/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/cube.html
+++ b/iris/docs/v1.7.2/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/exceptions.html
+++ b/iris/docs/v1.7.2/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.7.2/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.7.2/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/io.html
+++ b/iris/docs/v1.7.2/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.7.2/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/iterate.html
+++ b/iris/docs/v1.7.2/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/palette.html
+++ b/iris/docs/v1.7.2/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/pandas.html
+++ b/iris/docs/v1.7.2/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/plot.html
+++ b/iris/docs/v1.7.2/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/proxy.html
+++ b/iris/docs/v1.7.2/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/quickplot.html
+++ b/iris/docs/v1.7.2/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/std_names.html
+++ b/iris/docs/v1.7.2/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/symbols.html
+++ b/iris/docs/v1.7.2/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/time.html
+++ b/iris/docs/v1.7.2/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/unit.html
+++ b/iris/docs/v1.7.2/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/iris/iris/util.html
+++ b/iris/docs/v1.7.2/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/search.html
+++ b/iris/docs/v1.7.2/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.7.2/userguide/citation.html
+++ b/iris/docs/v1.7.2/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/cube_maths.html
+++ b/iris/docs/v1.7.2/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/cube_statistics.html
+++ b/iris/docs/v1.7.2/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/end_of_userguide.html
+++ b/iris/docs/v1.7.2/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/index.html
+++ b/iris/docs/v1.7.2/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.7.2/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/iris_cubes.html
+++ b/iris/docs/v1.7.2/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.7.2/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.7.2/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.7.2/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.7.2/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.0.html
+++ b/iris/docs/v1.7.2/whatsnew/1.0.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.1.html
+++ b/iris/docs/v1.7.2/whatsnew/1.1.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.2.html
+++ b/iris/docs/v1.7.2/whatsnew/1.2.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.3.html
+++ b/iris/docs/v1.7.2/whatsnew/1.3.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.4.html
+++ b/iris/docs/v1.7.2/whatsnew/1.4.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.5.html
+++ b/iris/docs/v1.7.2/whatsnew/1.5.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.6.html
+++ b/iris/docs/v1.7.2/whatsnew/1.6.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/1.7.html
+++ b/iris/docs/v1.7.2/whatsnew/1.7.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whatsnew/index.html
+++ b/iris/docs/v1.7.2/whatsnew/index.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whitepapers/index.html
+++ b/iris/docs/v1.7.2/whitepapers/index.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.2/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.7.2/whitepapers/um_files_loading.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/contents.html
+++ b/iris/docs/v1.7.3/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/copyright.html
+++ b/iris/docs/v1.7.3/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.7.3/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/documenting/index.html
+++ b/iris/docs/v1.7.3/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.7.3/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.7.3/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/index.html
+++ b/iris/docs/v1.7.3/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/pulls.html
+++ b/iris/docs/v1.7.3/developers_guide/pulls.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/developers_guide/tests.html
+++ b/iris/docs/v1.7.3/developers_guide/tests.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.7.3/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.7.3/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.7.3/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/TEC.html
+++ b/iris/docs/v1.7.3/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/anomaly_log_colouring.html
+++ b/iris/docs/v1.7.3/examples/graphics/anomaly_log_colouring.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/atlantic_profiles.html
+++ b/iris/docs/v1.7.3/examples/graphics/atlantic_profiles.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/cross_section.html
+++ b/iris/docs/v1.7.3/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/custom_aggregation.html
+++ b/iris/docs/v1.7.3/examples/graphics/custom_aggregation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.7.3/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.7.3/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/global_map.html
+++ b/iris/docs/v1.7.3/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.7.3/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/index.html
+++ b/iris/docs/v1.7.3/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.7.3/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.7.3/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/orca_projection.html
+++ b/iris/docs/v1.7.3/examples/graphics/orca_projection.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/polar_stereo.html
+++ b/iris/docs/v1.7.3/examples/graphics/polar_stereo.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/projections_and_annotations.html
+++ b/iris/docs/v1.7.3/examples/graphics/projections_and_annotations.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.7.3/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/examples/index.html
+++ b/iris/docs/v1.7.3/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/gallery.html
+++ b/iris/docs/v1.7.3/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/genindex.html
+++ b/iris/docs/v1.7.3/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/installing.html
+++ b/iris/docs/v1.7.3/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris.html
+++ b/iris/docs/v1.7.3/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/stats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.7.3/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/aux_factory.html
+++ b/iris/docs/v1.7.3/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/config.html
+++ b/iris/docs/v1.7.3/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.7.3/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/coord_systems.html
+++ b/iris/docs/v1.7.3/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/coords.html
+++ b/iris/docs/v1.7.3/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/cube.html
+++ b/iris/docs/v1.7.3/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/exceptions.html
+++ b/iris/docs/v1.7.3/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/animate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/equalise_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.7.3/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/grib/load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/name.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/name_loaders.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/pp_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.7.3/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/io.html
+++ b/iris/docs/v1.7.3/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.7.3/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/iterate.html
+++ b/iris/docs/v1.7.3/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/palette.html
+++ b/iris/docs/v1.7.3/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/pandas.html
+++ b/iris/docs/v1.7.3/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/plot.html
+++ b/iris/docs/v1.7.3/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/proxy.html
+++ b/iris/docs/v1.7.3/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/quickplot.html
+++ b/iris/docs/v1.7.3/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/std_names.html
+++ b/iris/docs/v1.7.3/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/symbols.html
+++ b/iris/docs/v1.7.3/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/time.html
+++ b/iris/docs/v1.7.3/iris/iris/time.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/unit.html
+++ b/iris/docs/v1.7.3/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/iris/iris/util.html
+++ b/iris/docs/v1.7.3/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/search.html
+++ b/iris/docs/v1.7.3/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.7.3/userguide/citation.html
+++ b/iris/docs/v1.7.3/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/cube_maths.html
+++ b/iris/docs/v1.7.3/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/cube_statistics.html
+++ b/iris/docs/v1.7.3/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/end_of_userguide.html
+++ b/iris/docs/v1.7.3/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/index.html
+++ b/iris/docs/v1.7.3/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.7.3/userguide/interpolation_and_regridding.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/iris_cubes.html
+++ b/iris/docs/v1.7.3/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.7.3/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.7.3/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.7.3/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.7.3/userguide/subsetting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.0.html
+++ b/iris/docs/v1.7.3/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.1.html
+++ b/iris/docs/v1.7.3/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.2.html
+++ b/iris/docs/v1.7.3/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.3.html
+++ b/iris/docs/v1.7.3/whatsnew/1.3.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.4.html
+++ b/iris/docs/v1.7.3/whatsnew/1.4.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.5.html
+++ b/iris/docs/v1.7.3/whatsnew/1.5.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.6.html
+++ b/iris/docs/v1.7.3/whatsnew/1.6.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/1.7.html
+++ b/iris/docs/v1.7.3/whatsnew/1.7.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whatsnew/index.html
+++ b/iris/docs/v1.7.3/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whitepapers/index.html
+++ b/iris/docs/v1.7.3/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7.3/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.7.3/whitepapers/um_files_loading.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/contents.html
+++ b/iris/docs/v1.7/contents.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/copyright.html
+++ b/iris/docs/v1.7/copyright.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.7/developers_guide/documenting/docstrings.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/documenting/index.html
+++ b/iris/docs/v1.7/developers_guide/documenting/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.7/developers_guide/documenting/rest_guide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/configure_git.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/development_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/following_latest.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/forking_hell.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/git_development.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/git_install.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/git_intro.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/git_resources.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/maintainer_workflow.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/patching.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.7/developers_guide/gitwash/set_up_fork.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/index.html
+++ b/iris/docs/v1.7/developers_guide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/pulls.html
+++ b/iris/docs/v1.7/developers_guide/pulls.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/developers_guide/tests.html
+++ b/iris/docs/v1.7/developers_guide/tests.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/COP_1d_plot.html
+++ b/iris/docs/v1.7/examples/graphics/COP_1d_plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/COP_maps.html
+++ b/iris/docs/v1.7/examples/graphics/COP_maps.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/SOI_filtering.html
+++ b/iris/docs/v1.7/examples/graphics/SOI_filtering.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/TEC.html
+++ b/iris/docs/v1.7/examples/graphics/TEC.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/anomaly_log_colouring.html
+++ b/iris/docs/v1.7/examples/graphics/anomaly_log_colouring.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/atlantic_profiles.html
+++ b/iris/docs/v1.7/examples/graphics/atlantic_profiles.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/cross_section.html
+++ b/iris/docs/v1.7/examples/graphics/cross_section.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/custom_aggregation.html
+++ b/iris/docs/v1.7/examples/graphics/custom_aggregation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/custom_file_loading.html
+++ b/iris/docs/v1.7/examples/graphics/custom_file_loading.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/deriving_phenomena.html
+++ b/iris/docs/v1.7/examples/graphics/deriving_phenomena.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/global_map.html
+++ b/iris/docs/v1.7/examples/graphics/global_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/hovmoller.html
+++ b/iris/docs/v1.7/examples/graphics/hovmoller.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/index.html
+++ b/iris/docs/v1.7/examples/graphics/index.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/lagged_ensemble.html
+++ b/iris/docs/v1.7/examples/graphics/lagged_ensemble.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/lineplot_with_legend.html
+++ b/iris/docs/v1.7/examples/graphics/lineplot_with_legend.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/orca_projection.html
+++ b/iris/docs/v1.7/examples/graphics/orca_projection.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/polar_stereo.html
+++ b/iris/docs/v1.7/examples/graphics/polar_stereo.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/projections_and_annotations.html
+++ b/iris/docs/v1.7/examples/graphics/projections_and_annotations.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/graphics/rotated_pole_mapping.html
+++ b/iris/docs/v1.7/examples/graphics/rotated_pole_mapping.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/examples/index.html
+++ b/iris/docs/v1.7/examples/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/gallery.html
+++ b/iris/docs/v1.7/gallery.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/genindex.html
+++ b/iris/docs/v1.7/genindex.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/installing.html
+++ b/iris/docs/v1.7/installing.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris.html
+++ b/iris/docs/v1.7/iris/iris.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis.html
+++ b/iris/docs/v1.7/iris/iris/analysis.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.7/iris/iris/analysis/calculus.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.7/iris/iris/analysis/cartography.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.7/iris/iris/analysis/geometry.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.7/iris/iris/analysis/interpolate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.7/iris/iris/analysis/maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.7/iris/iris/analysis/stats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.7/iris/iris/analysis/trajectory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/aux_factory.html
+++ b/iris/docs/v1.7/iris/iris/aux_factory.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/config.html
+++ b/iris/docs/v1.7/iris/iris/config.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.7/iris/iris/coord_categorisation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/coord_systems.html
+++ b/iris/docs/v1.7/iris/iris/coord_systems.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/coords.html
+++ b/iris/docs/v1.7/iris/iris/coords.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/cube.html
+++ b/iris/docs/v1.7/iris/iris/cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/exceptions.html
+++ b/iris/docs/v1.7/iris/iris/exceptions.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental.html
+++ b/iris/docs/v1.7/iris/iris/experimental.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.7/iris/iris/experimental/animate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.7/iris/iris/experimental/concatenate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.7/iris/iris/experimental/equalise_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/fileformats.html
+++ b/iris/docs/v1.7/iris/iris/experimental/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.7/iris/iris/experimental/raster.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.7/iris/iris/experimental/regrid.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.7/iris/iris/experimental/regrid_conservative.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats.html
+++ b/iris/docs/v1.7/iris/iris/fileformats.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/abf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/cf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/dot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/ff.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/grib.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/grib/grib_save_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/grib/load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/name.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/name_loaders.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/netcdf.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/nimrod.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/nimrod_load_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/pp.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/pp_packing.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/pp_rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/rules.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.7/iris/iris/fileformats/um_cf_map.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/io.html
+++ b/iris/docs/v1.7/iris/iris/io.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.7/iris/iris/io/format_picker.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/iterate.html
+++ b/iris/docs/v1.7/iris/iris/iterate.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/palette.html
+++ b/iris/docs/v1.7/iris/iris/palette.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/pandas.html
+++ b/iris/docs/v1.7/iris/iris/pandas.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/plot.html
+++ b/iris/docs/v1.7/iris/iris/plot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/proxy.html
+++ b/iris/docs/v1.7/iris/iris/proxy.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/quickplot.html
+++ b/iris/docs/v1.7/iris/iris/quickplot.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/std_names.html
+++ b/iris/docs/v1.7/iris/iris/std_names.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/symbols.html
+++ b/iris/docs/v1.7/iris/iris/symbols.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/time.html
+++ b/iris/docs/v1.7/iris/iris/time.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/unit.html
+++ b/iris/docs/v1.7/iris/iris/unit.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/iris/iris/util.html
+++ b/iris/docs/v1.7/iris/iris/util.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/search.html
+++ b/iris/docs/v1.7/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.7/userguide/citation.html
+++ b/iris/docs/v1.7/userguide/citation.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/cube_maths.html
+++ b/iris/docs/v1.7/userguide/cube_maths.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/cube_statistics.html
+++ b/iris/docs/v1.7/userguide/cube_statistics.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/end_of_userguide.html
+++ b/iris/docs/v1.7/userguide/end_of_userguide.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/index.html
+++ b/iris/docs/v1.7/userguide/index.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.7/userguide/interpolation_and_regridding.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/iris_cubes.html
+++ b/iris/docs/v1.7/userguide/iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.7/userguide/loading_iris_cubes.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.7/userguide/navigating_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.7/userguide/plotting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.7/userguide/subsetting_a_cube.html
@@ -35,7 +35,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.0.html
+++ b/iris/docs/v1.7/whatsnew/1.0.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.1.html
+++ b/iris/docs/v1.7/whatsnew/1.1.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.2.html
+++ b/iris/docs/v1.7/whatsnew/1.2.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.3.html
+++ b/iris/docs/v1.7/whatsnew/1.3.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.4.html
+++ b/iris/docs/v1.7/whatsnew/1.4.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.5.html
+++ b/iris/docs/v1.7/whatsnew/1.5.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.6.html
+++ b/iris/docs/v1.7/whatsnew/1.6.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/1.7.html
+++ b/iris/docs/v1.7/whatsnew/1.7.html
@@ -34,7 +34,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whatsnew/index.html
+++ b/iris/docs/v1.7/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whitepapers/index.html
+++ b/iris/docs/v1.7/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.7/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.7/whitepapers/um_files_loading.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/contents.html
+++ b/iris/docs/v1.8.0/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/copyright.html
+++ b/iris/docs/v1.8.0/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/deprecations.html
+++ b/iris/docs/v1.8.0/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.8.0/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/documenting/index.html
+++ b/iris/docs/v1.8.0/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.8.0/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.8.0/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/index.html
+++ b/iris/docs/v1.8.0/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/pulls.html
+++ b/iris/docs/v1.8.0/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/developers_guide/tests.html
+++ b/iris/docs/v1.8.0/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.8.0/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.8.0/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/cross_section.html
+++ b/iris/docs/v1.8.0/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.8.0/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.8.0/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/global_map.html
+++ b/iris/docs/v1.8.0/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/index.html
+++ b/iris/docs/v1.8.0/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.8.0/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/orca_projection.html
+++ b/iris/docs/v1.8.0/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/polar_stereo.html
+++ b/iris/docs/v1.8.0/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.8.0/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.8.0/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.8.0/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/index.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.8.0/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.8.0/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/Oceanography/index.html
+++ b/iris/docs/v1.8.0/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/examples/index.html
+++ b/iris/docs/v1.8.0/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/gallery.html
+++ b/iris/docs/v1.8.0/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/genindex.html
+++ b/iris/docs/v1.8.0/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/installing.html
+++ b/iris/docs/v1.8.0/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris.html
+++ b/iris/docs/v1.8.0/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.8.0/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/aux_factory.html
+++ b/iris/docs/v1.8.0/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/config.html
+++ b/iris/docs/v1.8.0/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.8.0/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/coord_systems.html
+++ b/iris/docs/v1.8.0/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/coords.html
+++ b/iris/docs/v1.8.0/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/cube.html
+++ b/iris/docs/v1.8.0/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/exceptions.html
+++ b/iris/docs/v1.8.0/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/experimental/um.html
+++ b/iris/docs/v1.8.0/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.8.0/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/io.html
+++ b/iris/docs/v1.8.0/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.8.0/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/iterate.html
+++ b/iris/docs/v1.8.0/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/palette.html
+++ b/iris/docs/v1.8.0/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/pandas.html
+++ b/iris/docs/v1.8.0/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/plot.html
+++ b/iris/docs/v1.8.0/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/proxy.html
+++ b/iris/docs/v1.8.0/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/quickplot.html
+++ b/iris/docs/v1.8.0/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/std_names.html
+++ b/iris/docs/v1.8.0/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/symbols.html
+++ b/iris/docs/v1.8.0/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/time.html
+++ b/iris/docs/v1.8.0/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/unit.html
+++ b/iris/docs/v1.8.0/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/iris/iris/util.html
+++ b/iris/docs/v1.8.0/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/search.html
+++ b/iris/docs/v1.8.0/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.8.0/userguide/citation.html
+++ b/iris/docs/v1.8.0/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/cube_maths.html
+++ b/iris/docs/v1.8.0/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/cube_statistics.html
+++ b/iris/docs/v1.8.0/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/end_of_userguide.html
+++ b/iris/docs/v1.8.0/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/index.html
+++ b/iris/docs/v1.8.0/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.8.0/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/iris_cubes.html
+++ b/iris/docs/v1.8.0/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.8.0/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/merge_and_concat.html
+++ b/iris/docs/v1.8.0/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.8.0/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.8.0/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.8.0/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.0.html
+++ b/iris/docs/v1.8.0/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.1.html
+++ b/iris/docs/v1.8.0/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.2.html
+++ b/iris/docs/v1.8.0/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.3.html
+++ b/iris/docs/v1.8.0/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.4.html
+++ b/iris/docs/v1.8.0/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.5.html
+++ b/iris/docs/v1.8.0/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.6.html
+++ b/iris/docs/v1.8.0/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.7.html
+++ b/iris/docs/v1.8.0/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/1.8.html
+++ b/iris/docs/v1.8.0/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whatsnew/index.html
+++ b/iris/docs/v1.8.0/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whitepapers/index.html
+++ b/iris/docs/v1.8.0/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.8.0/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/contents.html
+++ b/iris/docs/v1.8.1/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/copyright.html
+++ b/iris/docs/v1.8.1/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/deprecations.html
+++ b/iris/docs/v1.8.1/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.8.1/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/documenting/index.html
+++ b/iris/docs/v1.8.1/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.8.1/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.8.1/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/index.html
+++ b/iris/docs/v1.8.1/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/pulls.html
+++ b/iris/docs/v1.8.1/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/developers_guide/tests.html
+++ b/iris/docs/v1.8.1/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.8.1/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.8.1/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/cross_section.html
+++ b/iris/docs/v1.8.1/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.8.1/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.8.1/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/global_map.html
+++ b/iris/docs/v1.8.1/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/index.html
+++ b/iris/docs/v1.8.1/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.8.1/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/orca_projection.html
+++ b/iris/docs/v1.8.1/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/polar_stereo.html
+++ b/iris/docs/v1.8.1/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.8.1/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.8.1/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.8.1/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/index.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.8.1/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.8.1/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/Oceanography/index.html
+++ b/iris/docs/v1.8.1/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/examples/index.html
+++ b/iris/docs/v1.8.1/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/gallery.html
+++ b/iris/docs/v1.8.1/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/genindex.html
+++ b/iris/docs/v1.8.1/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/installing.html
+++ b/iris/docs/v1.8.1/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris.html
+++ b/iris/docs/v1.8.1/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.8.1/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/aux_factory.html
+++ b/iris/docs/v1.8.1/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/config.html
+++ b/iris/docs/v1.8.1/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.8.1/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/coord_systems.html
+++ b/iris/docs/v1.8.1/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/coords.html
+++ b/iris/docs/v1.8.1/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/cube.html
+++ b/iris/docs/v1.8.1/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/exceptions.html
+++ b/iris/docs/v1.8.1/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/experimental/um.html
+++ b/iris/docs/v1.8.1/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/um/packing.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/um/packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.8.1/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/io.html
+++ b/iris/docs/v1.8.1/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.8.1/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/iterate.html
+++ b/iris/docs/v1.8.1/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/palette.html
+++ b/iris/docs/v1.8.1/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/pandas.html
+++ b/iris/docs/v1.8.1/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/plot.html
+++ b/iris/docs/v1.8.1/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/proxy.html
+++ b/iris/docs/v1.8.1/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/quickplot.html
+++ b/iris/docs/v1.8.1/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/std_names.html
+++ b/iris/docs/v1.8.1/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/symbols.html
+++ b/iris/docs/v1.8.1/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/time.html
+++ b/iris/docs/v1.8.1/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/unit.html
+++ b/iris/docs/v1.8.1/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/iris/iris/util.html
+++ b/iris/docs/v1.8.1/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/search.html
+++ b/iris/docs/v1.8.1/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.8.1/userguide/citation.html
+++ b/iris/docs/v1.8.1/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/cube_maths.html
+++ b/iris/docs/v1.8.1/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/cube_statistics.html
+++ b/iris/docs/v1.8.1/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/end_of_userguide.html
+++ b/iris/docs/v1.8.1/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/index.html
+++ b/iris/docs/v1.8.1/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.8.1/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/iris_cubes.html
+++ b/iris/docs/v1.8.1/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.8.1/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/merge_and_concat.html
+++ b/iris/docs/v1.8.1/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.8.1/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.8.1/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.8.1/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.0.html
+++ b/iris/docs/v1.8.1/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.1.html
+++ b/iris/docs/v1.8.1/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.2.html
+++ b/iris/docs/v1.8.1/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.3.html
+++ b/iris/docs/v1.8.1/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.4.html
+++ b/iris/docs/v1.8.1/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.5.html
+++ b/iris/docs/v1.8.1/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.6.html
+++ b/iris/docs/v1.8.1/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.7.html
+++ b/iris/docs/v1.8.1/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/1.8.html
+++ b/iris/docs/v1.8.1/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whatsnew/index.html
+++ b/iris/docs/v1.8.1/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whitepapers/index.html
+++ b/iris/docs/v1.8.1/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.8.1/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.8.1/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/contents.html
+++ b/iris/docs/v1.9.0/html/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/copyright.html
+++ b/iris/docs/v1.9.0/html/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/deprecations.html
+++ b/iris/docs/v1.9.0/html/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.9.0/html/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/documenting/index.html
+++ b/iris/docs/v1.9.0/html/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.9.0/html/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.9.0/html/developers_guide/documenting/whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.9.0/html/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/index.html
+++ b/iris/docs/v1.9.0/html/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/pulls.html
+++ b/iris/docs/v1.9.0/html/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/developers_guide/tests.html
+++ b/iris/docs/v1.9.0/html/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.9.0/html/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.9.0/html/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/cross_section.html
+++ b/iris/docs/v1.9.0/html/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.9.0/html/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.9.0/html/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/global_map.html
+++ b/iris/docs/v1.9.0/html/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/index.html
+++ b/iris/docs/v1.9.0/html/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.9.0/html/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/orca_projection.html
+++ b/iris/docs/v1.9.0/html/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/polar_stereo.html
+++ b/iris/docs/v1.9.0/html/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.9.0/html/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.9.0/html/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.9.0/html/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/index.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.9.0/html/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.9.0/html/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/Oceanography/index.html
+++ b/iris/docs/v1.9.0/html/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/examples/index.html
+++ b/iris/docs/v1.9.0/html/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/gallery.html
+++ b/iris/docs/v1.9.0/html/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/genindex.html
+++ b/iris/docs/v1.9.0/html/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/installing.html
+++ b/iris/docs/v1.9.0/html/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris.html
+++ b/iris/docs/v1.9.0/html/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.9.0/html/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/aux_factory.html
+++ b/iris/docs/v1.9.0/html/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/config.html
+++ b/iris/docs/v1.9.0/html/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.9.0/html/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/coord_systems.html
+++ b/iris/docs/v1.9.0/html/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/coords.html
+++ b/iris/docs/v1.9.0/html/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/cube.html
+++ b/iris/docs/v1.9.0/html/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/exceptions.html
+++ b/iris/docs/v1.9.0/html/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/experimental/um.html
+++ b/iris/docs/v1.9.0/html/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.9.0/html/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/io.html
+++ b/iris/docs/v1.9.0/html/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.9.0/html/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/iterate.html
+++ b/iris/docs/v1.9.0/html/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/palette.html
+++ b/iris/docs/v1.9.0/html/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/pandas.html
+++ b/iris/docs/v1.9.0/html/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/plot.html
+++ b/iris/docs/v1.9.0/html/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/proxy.html
+++ b/iris/docs/v1.9.0/html/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/quickplot.html
+++ b/iris/docs/v1.9.0/html/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/std_names.html
+++ b/iris/docs/v1.9.0/html/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/symbols.html
+++ b/iris/docs/v1.9.0/html/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/time.html
+++ b/iris/docs/v1.9.0/html/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/unit.html
+++ b/iris/docs/v1.9.0/html/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/iris/iris/util.html
+++ b/iris/docs/v1.9.0/html/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/search.html
+++ b/iris/docs/v1.9.0/html/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.9.0/html/userguide/citation.html
+++ b/iris/docs/v1.9.0/html/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/cube_maths.html
+++ b/iris/docs/v1.9.0/html/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/cube_statistics.html
+++ b/iris/docs/v1.9.0/html/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/end_of_userguide.html
+++ b/iris/docs/v1.9.0/html/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/index.html
+++ b/iris/docs/v1.9.0/html/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.9.0/html/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/iris_cubes.html
+++ b/iris/docs/v1.9.0/html/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.9.0/html/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/merge_and_concat.html
+++ b/iris/docs/v1.9.0/html/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.9.0/html/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.9.0/html/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.9.0/html/userguide/saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.9.0/html/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.0.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.1.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.2.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.3.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.4.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.5.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.6.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.7.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.8.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/1.9.html
+++ b/iris/docs/v1.9.0/html/whatsnew/1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whatsnew/index.html
+++ b/iris/docs/v1.9.0/html/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whitepapers/index.html
+++ b/iris/docs/v1.9.0/html/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.0/html/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.9.0/html/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/developers_guide/release.html
+++ b/iris/docs/v1.9.1/developers_guide/release.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.9.1/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.9.1/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/cross_section.html
+++ b/iris/docs/v1.9.1/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.9.1/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.9.1/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/global_map.html
+++ b/iris/docs/v1.9.1/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.9.1/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/orca_projection.html
+++ b/iris/docs/v1.9.1/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/polar_stereo.html
+++ b/iris/docs/v1.9.1/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.9.1/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.9.1/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.9.1/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.9.1/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.9.1/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/gallery.html
+++ b/iris/docs/v1.9.1/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/iris/iris.html
+++ b/iris/docs/v1.9.1/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/iris/iris/io.html
+++ b/iris/docs/v1.9.1/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.1/whatsnew/1.8.html
+++ b/iris/docs/v1.9.1/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/contents.html
+++ b/iris/docs/v1.9.2/contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/copyright.html
+++ b/iris/docs/v1.9.2/copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/deprecations.html
+++ b/iris/docs/v1.9.2/developers_guide/deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v1.9.2/developers_guide/documenting/docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/documenting/index.html
+++ b/iris/docs/v1.9.2/developers_guide/documenting/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v1.9.2/developers_guide/documenting/rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v1.9.2/developers_guide/documenting/whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/index.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/patching.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v1.9.2/developers_guide/gitwash/set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/index.html
+++ b/iris/docs/v1.9.2/developers_guide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/pulls.html
+++ b/iris/docs/v1.9.2/developers_guide/pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/release.html
+++ b/iris/docs/v1.9.2/developers_guide/release.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/developers_guide/tests.html
+++ b/iris/docs/v1.9.2/developers_guide/tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/SOI_filtering.html
+++ b/iris/docs/v1.9.2/examples/General/SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v1.9.2/examples/General/anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/cross_section.html
+++ b/iris/docs/v1.9.2/examples/General/cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/custom_aggregation.html
+++ b/iris/docs/v1.9.2/examples/General/custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/custom_file_loading.html
+++ b/iris/docs/v1.9.2/examples/General/custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/global_map.html
+++ b/iris/docs/v1.9.2/examples/General/global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/index.html
+++ b/iris/docs/v1.9.2/examples/General/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v1.9.2/examples/General/lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/orca_projection.html
+++ b/iris/docs/v1.9.2/examples/General/orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/polar_stereo.html
+++ b/iris/docs/v1.9.2/examples/General/polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/polynomial_fit.html
+++ b/iris/docs/v1.9.2/examples/General/polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/projections_and_annotations.html
+++ b/iris/docs/v1.9.2/examples/General/projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v1.9.2/examples/General/rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/COP_1d_plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/TEC.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/index.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v1.9.2/examples/Meteorology/lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v1.9.2/examples/Oceanography/atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/Oceanography/index.html
+++ b/iris/docs/v1.9.2/examples/Oceanography/index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/examples/index.html
+++ b/iris/docs/v1.9.2/examples/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/gallery.html
+++ b/iris/docs/v1.9.2/gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/genindex.html
+++ b/iris/docs/v1.9.2/genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/installing.html
+++ b/iris/docs/v1.9.2/installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris.html
+++ b/iris/docs/v1.9.2/iris/iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/calculus.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/cartography.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/geometry.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/maths.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/stats.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v1.9.2/iris/iris/analysis/trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/aux_factory.html
+++ b/iris/docs/v1.9.2/iris/iris/aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/config.html
+++ b/iris/docs/v1.9.2/iris/iris/config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/coord_categorisation.html
+++ b/iris/docs/v1.9.2/iris/iris/coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/coord_systems.html
+++ b/iris/docs/v1.9.2/iris/iris/coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/coords.html
+++ b/iris/docs/v1.9.2/iris/iris/coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/cube.html
+++ b/iris/docs/v1.9.2/iris/iris/cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/exceptions.html
+++ b/iris/docs/v1.9.2/iris/iris/exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/animate.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/raster.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/regrid.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/experimental/um.html
+++ b/iris/docs/v1.9.2/iris/iris/experimental/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/abf.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/cf.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/dot.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/ff.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/grib.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/grib/grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/grib/load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/name.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/pp.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/rules.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/um.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v1.9.2/iris/iris/fileformats/um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/io.html
+++ b/iris/docs/v1.9.2/iris/iris/io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/io/format_picker.html
+++ b/iris/docs/v1.9.2/iris/iris/io/format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/iterate.html
+++ b/iris/docs/v1.9.2/iris/iris/iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/palette.html
+++ b/iris/docs/v1.9.2/iris/iris/palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/pandas.html
+++ b/iris/docs/v1.9.2/iris/iris/pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/plot.html
+++ b/iris/docs/v1.9.2/iris/iris/plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/proxy.html
+++ b/iris/docs/v1.9.2/iris/iris/proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/quickplot.html
+++ b/iris/docs/v1.9.2/iris/iris/quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/std_names.html
+++ b/iris/docs/v1.9.2/iris/iris/std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/symbols.html
+++ b/iris/docs/v1.9.2/iris/iris/symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/time.html
+++ b/iris/docs/v1.9.2/iris/iris/time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/unit.html
+++ b/iris/docs/v1.9.2/iris/iris/unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/iris/iris/util.html
+++ b/iris/docs/v1.9.2/iris/iris/util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/search.html
+++ b/iris/docs/v1.9.2/search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/iris/docs/v1.9.2/userguide/citation.html
+++ b/iris/docs/v1.9.2/userguide/citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/cube_maths.html
+++ b/iris/docs/v1.9.2/userguide/cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/cube_statistics.html
+++ b/iris/docs/v1.9.2/userguide/cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/end_of_userguide.html
+++ b/iris/docs/v1.9.2/userguide/end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/index.html
+++ b/iris/docs/v1.9.2/userguide/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v1.9.2/userguide/interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/iris_cubes.html
+++ b/iris/docs/v1.9.2/userguide/iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/loading_iris_cubes.html
+++ b/iris/docs/v1.9.2/userguide/loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/merge_and_concat.html
+++ b/iris/docs/v1.9.2/userguide/merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/navigating_a_cube.html
+++ b/iris/docs/v1.9.2/userguide/navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/plotting_a_cube.html
+++ b/iris/docs/v1.9.2/userguide/plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/saving_iris_cubes.html
+++ b/iris/docs/v1.9.2/userguide/saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/userguide/subsetting_a_cube.html
+++ b/iris/docs/v1.9.2/userguide/subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.0.html
+++ b/iris/docs/v1.9.2/whatsnew/1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.1.html
+++ b/iris/docs/v1.9.2/whatsnew/1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.2.html
+++ b/iris/docs/v1.9.2/whatsnew/1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.3.html
+++ b/iris/docs/v1.9.2/whatsnew/1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.4.html
+++ b/iris/docs/v1.9.2/whatsnew/1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.5.html
+++ b/iris/docs/v1.9.2/whatsnew/1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.6.html
+++ b/iris/docs/v1.9.2/whatsnew/1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.7.html
+++ b/iris/docs/v1.9.2/whatsnew/1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.8.html
+++ b/iris/docs/v1.9.2/whatsnew/1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/1.9.html
+++ b/iris/docs/v1.9.2/whatsnew/1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whatsnew/index.html
+++ b/iris/docs/v1.9.2/whatsnew/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whitepapers/index.html
+++ b/iris/docs/v1.9.2/whitepapers/index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v1.9.2/whitepapers/um_files_loading.html
+++ b/iris/docs/v1.9.2/whitepapers/um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v2.0/contents.html
+++ b/iris/docs/v2.0/contents.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/copyright.html
+++ b/iris/docs/v2.0/copyright.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/deprecations.html
+++ b/iris/docs/v2.0/developers_guide/deprecations.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v2.0/developers_guide/documenting/docstrings.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/documenting/index.html
+++ b/iris/docs/v2.0/developers_guide/documenting/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v2.0/developers_guide/documenting/rest_guide.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v2.0/developers_guide/documenting/whats_new_contributions.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/configure_git.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/development_workflow.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/following_latest.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/forking_hell.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/git_development.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/git_install.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/git_intro.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/git_resources.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/index.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/maintainer_workflow.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/patching.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/patching.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v2.0/developers_guide/gitwash/set_up_fork.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/graphics_tests.html
+++ b/iris/docs/v2.0/developers_guide/graphics_tests.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/index.html
+++ b/iris/docs/v2.0/developers_guide/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/pulls.html
+++ b/iris/docs/v2.0/developers_guide/pulls.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/release.html
+++ b/iris/docs/v2.0/developers_guide/release.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/developers_guide/tests.html
+++ b/iris/docs/v2.0/developers_guide/tests.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/SOI_filtering.html
+++ b/iris/docs/v2.0/examples/General/SOI_filtering.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v2.0/examples/General/anomaly_log_colouring.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/coriolis_plot.html
+++ b/iris/docs/v2.0/examples/General/coriolis_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/cross_section.html
+++ b/iris/docs/v2.0/examples/General/cross_section.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/custom_aggregation.html
+++ b/iris/docs/v2.0/examples/General/custom_aggregation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/custom_file_loading.html
+++ b/iris/docs/v2.0/examples/General/custom_file_loading.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/global_map.html
+++ b/iris/docs/v2.0/examples/General/global_map.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/index.html
+++ b/iris/docs/v2.0/examples/General/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/inset_plot.html
+++ b/iris/docs/v2.0/examples/General/inset_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v2.0/examples/General/lineplot_with_legend.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/orca_projection.html
+++ b/iris/docs/v2.0/examples/General/orca_projection.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/polar_stereo.html
+++ b/iris/docs/v2.0/examples/General/polar_stereo.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/polynomial_fit.html
+++ b/iris/docs/v2.0/examples/General/polynomial_fit.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/projections_and_annotations.html
+++ b/iris/docs/v2.0/examples/General/projections_and_annotations.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v2.0/examples/General/rotated_pole_mapping.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v2.0/examples/Meteorology/COP_1d_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v2.0/examples/Meteorology/COP_maps.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/TEC.html
+++ b/iris/docs/v2.0/examples/Meteorology/TEC.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v2.0/examples/Meteorology/deriving_phenomena.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v2.0/examples/Meteorology/hovmoller.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/index.html
+++ b/iris/docs/v2.0/examples/Meteorology/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v2.0/examples/Meteorology/lagged_ensemble.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v2.0/examples/Meteorology/wind_speed.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v2.0/examples/Oceanography/atlantic_profiles.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/Oceanography/index.html
+++ b/iris/docs/v2.0/examples/Oceanography/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/examples/index.html
+++ b/iris/docs/v2.0/examples/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/gallery.html
+++ b/iris/docs/v2.0/gallery.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/genindex.html
+++ b/iris/docs/v2.0/genindex.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/installing.html
+++ b/iris/docs/v2.0/installing.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris.html
+++ b/iris/docs/v2.0/iris/iris.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis.html
+++ b/iris/docs/v2.0/iris/iris/analysis.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/calculus.html
+++ b/iris/docs/v2.0/iris/iris/analysis/calculus.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/cartography.html
+++ b/iris/docs/v2.0/iris/iris/analysis/cartography.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/geometry.html
+++ b/iris/docs/v2.0/iris/iris/analysis/geometry.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/maths.html
+++ b/iris/docs/v2.0/iris/iris/analysis/maths.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/stats.html
+++ b/iris/docs/v2.0/iris/iris/analysis/stats.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v2.0/iris/iris/analysis/trajectory.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/aux_factory.html
+++ b/iris/docs/v2.0/iris/iris/aux_factory.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/config.html
+++ b/iris/docs/v2.0/iris/iris/config.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/coord_categorisation.html
+++ b/iris/docs/v2.0/iris/iris/coord_categorisation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/coord_systems.html
+++ b/iris/docs/v2.0/iris/iris/coord_systems.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/coords.html
+++ b/iris/docs/v2.0/iris/iris/coords.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/cube.html
+++ b/iris/docs/v2.0/iris/iris/cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/exceptions.html
+++ b/iris/docs/v2.0/iris/iris/exceptions.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental.html
+++ b/iris/docs/v2.0/iris/iris/experimental.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/animate.html
+++ b/iris/docs/v2.0/iris/iris/experimental/animate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v2.0/iris/iris/experimental/concatenate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v2.0/iris/iris/experimental/equalise_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/raster.html
+++ b/iris/docs/v2.0/iris/iris/experimental/raster.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/regrid.html
+++ b/iris/docs/v2.0/iris/iris/experimental/regrid.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v2.0/iris/iris/experimental/regrid_conservative.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/stratify.html
+++ b/iris/docs/v2.0/iris/iris/experimental/stratify.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v2.0/iris/iris/experimental/ugrid.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/experimental/um.html
+++ b/iris/docs/v2.0/iris/iris/experimental/um.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats.html
+++ b/iris/docs/v2.0/iris/iris/fileformats.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/abf.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/abf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/cf.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/cf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/dot.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/dot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/name.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/name.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/name_loaders.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/netcdf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/nimrod.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/nimrod_load_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/pp.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/pp.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/pp_load_rules.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/pp_load_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/pp_save_rules.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/pp_save_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/rules.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/um.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/um.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v2.0/iris/iris/fileformats/um_cf_map.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/io.html
+++ b/iris/docs/v2.0/iris/iris/io.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/io/format_picker.html
+++ b/iris/docs/v2.0/iris/iris/io/format_picker.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/iterate.html
+++ b/iris/docs/v2.0/iris/iris/iterate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/palette.html
+++ b/iris/docs/v2.0/iris/iris/palette.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/pandas.html
+++ b/iris/docs/v2.0/iris/iris/pandas.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/plot.html
+++ b/iris/docs/v2.0/iris/iris/plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/quickplot.html
+++ b/iris/docs/v2.0/iris/iris/quickplot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/std_names.html
+++ b/iris/docs/v2.0/iris/iris/std_names.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/symbols.html
+++ b/iris/docs/v2.0/iris/iris/symbols.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/time.html
+++ b/iris/docs/v2.0/iris/iris/time.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/iris/iris/util.html
+++ b/iris/docs/v2.0/iris/iris/util.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/py-modindex.html
+++ b/iris/docs/v2.0/py-modindex.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
 

--- a/iris/docs/v2.0/search.html
+++ b/iris/docs/v2.0/search.html
@@ -28,7 +28,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head><body>

--- a/iris/docs/v2.0/userguide/citation.html
+++ b/iris/docs/v2.0/userguide/citation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/code_maintenance.html
+++ b/iris/docs/v2.0/userguide/code_maintenance.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/cube_maths.html
+++ b/iris/docs/v2.0/userguide/cube_maths.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/cube_statistics.html
+++ b/iris/docs/v2.0/userguide/cube_statistics.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/end_of_userguide.html
+++ b/iris/docs/v2.0/userguide/end_of_userguide.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/index.html
+++ b/iris/docs/v2.0/userguide/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v2.0/userguide/interpolation_and_regridding.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/iris_cubes.html
+++ b/iris/docs/v2.0/userguide/iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/loading_iris_cubes.html
+++ b/iris/docs/v2.0/userguide/loading_iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/merge_and_concat.html
+++ b/iris/docs/v2.0/userguide/merge_and_concat.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/navigating_a_cube.html
+++ b/iris/docs/v2.0/userguide/navigating_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/plotting_a_cube.html
+++ b/iris/docs/v2.0/userguide/plotting_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/real_and_lazy_data.html
+++ b/iris/docs/v2.0/userguide/real_and_lazy_data.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/saving_iris_cubes.html
+++ b/iris/docs/v2.0/userguide/saving_iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/userguide/subsetting_a_cube.html
+++ b/iris/docs/v2.0/userguide/subsetting_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.0.html
+++ b/iris/docs/v2.0/whatsnew/1.0.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.1.html
+++ b/iris/docs/v2.0/whatsnew/1.1.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.10.html
+++ b/iris/docs/v2.0/whatsnew/1.10.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.11.html
+++ b/iris/docs/v2.0/whatsnew/1.11.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.12.html
+++ b/iris/docs/v2.0/whatsnew/1.12.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.13.html
+++ b/iris/docs/v2.0/whatsnew/1.13.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.2.html
+++ b/iris/docs/v2.0/whatsnew/1.2.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.3.html
+++ b/iris/docs/v2.0/whatsnew/1.3.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.4.html
+++ b/iris/docs/v2.0/whatsnew/1.4.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.5.html
+++ b/iris/docs/v2.0/whatsnew/1.5.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.6.html
+++ b/iris/docs/v2.0/whatsnew/1.6.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.7.html
+++ b/iris/docs/v2.0/whatsnew/1.7.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.8.html
+++ b/iris/docs/v2.0/whatsnew/1.8.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/1.9.html
+++ b/iris/docs/v2.0/whatsnew/1.9.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/2.0.html
+++ b/iris/docs/v2.0/whatsnew/2.0.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whatsnew/index.html
+++ b/iris/docs/v2.0/whatsnew/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whitepapers/change_management.html
+++ b/iris/docs/v2.0/whitepapers/change_management.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whitepapers/index.html
+++ b/iris/docs/v2.0/whitepapers/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whitepapers/missing_data_handling.html
+++ b/iris/docs/v2.0/whitepapers/missing_data_handling.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.0/whitepapers/um_files_loading.html
+++ b/iris/docs/v2.0/whitepapers/um_files_loading.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head><body>
 <div style="background-color: white; text-align: left; padding: 1px 10px 1px 15px">

--- a/iris/docs/v2.1/contents.html
+++ b/iris/docs/v2.1/contents.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/copyright.html
+++ b/iris/docs/v2.1/copyright.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/dask_interface.html
+++ b/iris/docs/v2.1/developers_guide/dask_interface.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v2.1/developers_guide/deprecations.html
+++ b/iris/docs/v2.1/developers_guide/deprecations.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/documenting/docstrings.html
+++ b/iris/docs/v2.1/developers_guide/documenting/docstrings.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/documenting/index.html
+++ b/iris/docs/v2.1/developers_guide/documenting/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/documenting/rest_guide.html
+++ b/iris/docs/v2.1/developers_guide/documenting/rest_guide.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/documenting/whats_new_contributions.html
+++ b/iris/docs/v2.1/developers_guide/documenting/whats_new_contributions.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/configure_git.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/configure_git.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/development_workflow.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/development_workflow.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/following_latest.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/following_latest.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/forking_hell.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/forking_hell.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/git_development.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/git_development.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/git_install.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/git_install.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/git_intro.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/git_intro.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/git_resources.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/git_resources.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/index.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/maintainer_workflow.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/maintainer_workflow.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/patching.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/patching.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/gitwash/set_up_fork.html
+++ b/iris/docs/v2.1/developers_guide/gitwash/set_up_fork.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/graphics_tests.html
+++ b/iris/docs/v2.1/developers_guide/graphics_tests.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/index.html
+++ b/iris/docs/v2.1/developers_guide/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/pulls.html
+++ b/iris/docs/v2.1/developers_guide/pulls.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/release.html
+++ b/iris/docs/v2.1/developers_guide/release.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/developers_guide/tests.html
+++ b/iris/docs/v2.1/developers_guide/tests.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/SOI_filtering.html
+++ b/iris/docs/v2.1/examples/General/SOI_filtering.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/anomaly_log_colouring.html
+++ b/iris/docs/v2.1/examples/General/anomaly_log_colouring.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/coriolis_plot.html
+++ b/iris/docs/v2.1/examples/General/coriolis_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/cross_section.html
+++ b/iris/docs/v2.1/examples/General/cross_section.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/custom_aggregation.html
+++ b/iris/docs/v2.1/examples/General/custom_aggregation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/custom_file_loading.html
+++ b/iris/docs/v2.1/examples/General/custom_file_loading.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/global_map.html
+++ b/iris/docs/v2.1/examples/General/global_map.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/index.html
+++ b/iris/docs/v2.1/examples/General/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/inset_plot.html
+++ b/iris/docs/v2.1/examples/General/inset_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/lineplot_with_legend.html
+++ b/iris/docs/v2.1/examples/General/lineplot_with_legend.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/orca_projection.html
+++ b/iris/docs/v2.1/examples/General/orca_projection.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/polar_stereo.html
+++ b/iris/docs/v2.1/examples/General/polar_stereo.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/polynomial_fit.html
+++ b/iris/docs/v2.1/examples/General/polynomial_fit.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/projections_and_annotations.html
+++ b/iris/docs/v2.1/examples/General/projections_and_annotations.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/General/rotated_pole_mapping.html
+++ b/iris/docs/v2.1/examples/General/rotated_pole_mapping.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/COP_1d_plot.html
+++ b/iris/docs/v2.1/examples/Meteorology/COP_1d_plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/COP_maps.html
+++ b/iris/docs/v2.1/examples/Meteorology/COP_maps.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/TEC.html
+++ b/iris/docs/v2.1/examples/Meteorology/TEC.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/deriving_phenomena.html
+++ b/iris/docs/v2.1/examples/Meteorology/deriving_phenomena.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/hovmoller.html
+++ b/iris/docs/v2.1/examples/Meteorology/hovmoller.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/index.html
+++ b/iris/docs/v2.1/examples/Meteorology/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/lagged_ensemble.html
+++ b/iris/docs/v2.1/examples/Meteorology/lagged_ensemble.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Meteorology/wind_speed.html
+++ b/iris/docs/v2.1/examples/Meteorology/wind_speed.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Oceanography/atlantic_profiles.html
+++ b/iris/docs/v2.1/examples/Oceanography/atlantic_profiles.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/Oceanography/index.html
+++ b/iris/docs/v2.1/examples/Oceanography/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/examples/index.html
+++ b/iris/docs/v2.1/examples/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/gallery.html
+++ b/iris/docs/v2.1/gallery.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/genindex.html
+++ b/iris/docs/v2.1/genindex.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/index.html
+++ b/iris/docs/v2.1/index.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/installing.html
+++ b/iris/docs/v2.1/installing.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris.html
+++ b/iris/docs/v2.1/iris/iris.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis.html
+++ b/iris/docs/v2.1/iris/iris/analysis.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/calculus.html
+++ b/iris/docs/v2.1/iris/iris/analysis/calculus.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/cartography.html
+++ b/iris/docs/v2.1/iris/iris/analysis/cartography.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/geometry.html
+++ b/iris/docs/v2.1/iris/iris/analysis/geometry.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/interpolate.html
+++ b/iris/docs/v2.1/iris/iris/analysis/interpolate.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/maths.html
+++ b/iris/docs/v2.1/iris/iris/analysis/maths.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/stats.html
+++ b/iris/docs/v2.1/iris/iris/analysis/stats.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/analysis/trajectory.html
+++ b/iris/docs/v2.1/iris/iris/analysis/trajectory.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/aux_factory.html
+++ b/iris/docs/v2.1/iris/iris/aux_factory.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/config.html
+++ b/iris/docs/v2.1/iris/iris/config.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/coord_categorisation.html
+++ b/iris/docs/v2.1/iris/iris/coord_categorisation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/coord_systems.html
+++ b/iris/docs/v2.1/iris/iris/coord_systems.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/coords.html
+++ b/iris/docs/v2.1/iris/iris/coords.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/cube.html
+++ b/iris/docs/v2.1/iris/iris/cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/exceptions.html
+++ b/iris/docs/v2.1/iris/iris/exceptions.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental.html
+++ b/iris/docs/v2.1/iris/iris/experimental.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/animate.html
+++ b/iris/docs/v2.1/iris/iris/experimental/animate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/concatenate.html
+++ b/iris/docs/v2.1/iris/iris/experimental/concatenate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/equalise_cubes.html
+++ b/iris/docs/v2.1/iris/iris/experimental/equalise_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/fieldsfile.html
+++ b/iris/docs/v2.1/iris/iris/experimental/fieldsfile.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/raster.html
+++ b/iris/docs/v2.1/iris/iris/experimental/raster.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/regrid.html
+++ b/iris/docs/v2.1/iris/iris/experimental/regrid.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/regrid_conservative.html
+++ b/iris/docs/v2.1/iris/iris/experimental/regrid_conservative.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/representation.html
+++ b/iris/docs/v2.1/iris/iris/experimental/representation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/stratify.html
+++ b/iris/docs/v2.1/iris/iris/experimental/stratify.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/ugrid.html
+++ b/iris/docs/v2.1/iris/iris/experimental/ugrid.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/experimental/um.html
+++ b/iris/docs/v2.1/iris/iris/experimental/um.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats.html
+++ b/iris/docs/v2.1/iris/iris/fileformats.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/abf.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/abf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/cf.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/cf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/dot.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/dot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/ff.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/ff.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/grib.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/grib.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/grib/grib_phenom_translation.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/grib/grib_phenom_translation.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/grib/grib_save_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/grib/grib_save_rules.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/grib/load_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/grib/load_rules.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/grib/message.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/grib/message.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/name.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/name.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/name_loaders.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/name_loaders.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/netcdf.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/netcdf.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/nimrod.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/nimrod.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/nimrod_load_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/nimrod_load_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/pp.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/pp.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/pp_load_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/pp_load_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/pp_packing.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/pp_packing.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/pp_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/pp_rules.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/pp_save_rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/pp_save_rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/rules.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/rules.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/um.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/um.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/fileformats/um_cf_map.html
+++ b/iris/docs/v2.1/iris/iris/fileformats/um_cf_map.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/io.html
+++ b/iris/docs/v2.1/iris/iris/io.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/io/format_picker.html
+++ b/iris/docs/v2.1/iris/iris/io/format_picker.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/iterate.html
+++ b/iris/docs/v2.1/iris/iris/iterate.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/palette.html
+++ b/iris/docs/v2.1/iris/iris/palette.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/pandas.html
+++ b/iris/docs/v2.1/iris/iris/pandas.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/plot.html
+++ b/iris/docs/v2.1/iris/iris/plot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/proxy.html
+++ b/iris/docs/v2.1/iris/iris/proxy.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/quickplot.html
+++ b/iris/docs/v2.1/iris/iris/quickplot.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/std_names.html
+++ b/iris/docs/v2.1/iris/iris/std_names.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/symbols.html
+++ b/iris/docs/v2.1/iris/iris/symbols.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/time.html
+++ b/iris/docs/v2.1/iris/iris/time.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/unit.html
+++ b/iris/docs/v2.1/iris/iris/unit.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/iris/iris/util.html
+++ b/iris/docs/v2.1/iris/iris/util.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/py-modindex.html
+++ b/iris/docs/v2.1/py-modindex.html
@@ -22,7 +22,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/search.html
+++ b/iris/docs/v2.1/search.html
@@ -28,7 +28,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/citation.html
+++ b/iris/docs/v2.1/userguide/citation.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/code_maintenance.html
+++ b/iris/docs/v2.1/userguide/code_maintenance.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/cube_maths.html
+++ b/iris/docs/v2.1/userguide/cube_maths.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/cube_statistics.html
+++ b/iris/docs/v2.1/userguide/cube_statistics.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/end_of_userguide.html
+++ b/iris/docs/v2.1/userguide/end_of_userguide.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/index.html
+++ b/iris/docs/v2.1/userguide/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/interpolation_and_regridding.html
+++ b/iris/docs/v2.1/userguide/interpolation_and_regridding.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/iris_cubes.html
+++ b/iris/docs/v2.1/userguide/iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/loading_iris_cubes.html
+++ b/iris/docs/v2.1/userguide/loading_iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/merge_and_concat.html
+++ b/iris/docs/v2.1/userguide/merge_and_concat.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/navigating_a_cube.html
+++ b/iris/docs/v2.1/userguide/navigating_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/plotting_a_cube.html
+++ b/iris/docs/v2.1/userguide/plotting_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/real_and_lazy_data.html
+++ b/iris/docs/v2.1/userguide/real_and_lazy_data.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/saving_iris_cubes.html
+++ b/iris/docs/v2.1/userguide/saving_iris_cubes.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/userguide/subsetting_a_cube.html
+++ b/iris/docs/v2.1/userguide/subsetting_a_cube.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.0.html
+++ b/iris/docs/v2.1/whatsnew/1.0.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.1.html
+++ b/iris/docs/v2.1/whatsnew/1.1.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.10.html
+++ b/iris/docs/v2.1/whatsnew/1.10.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.11.html
+++ b/iris/docs/v2.1/whatsnew/1.11.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.12.html
+++ b/iris/docs/v2.1/whatsnew/1.12.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.13.html
+++ b/iris/docs/v2.1/whatsnew/1.13.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.2.html
+++ b/iris/docs/v2.1/whatsnew/1.2.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.3.html
+++ b/iris/docs/v2.1/whatsnew/1.3.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.4.html
+++ b/iris/docs/v2.1/whatsnew/1.4.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.5.html
+++ b/iris/docs/v2.1/whatsnew/1.5.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.6.html
+++ b/iris/docs/v2.1/whatsnew/1.6.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.7.html
+++ b/iris/docs/v2.1/whatsnew/1.7.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.8.html
+++ b/iris/docs/v2.1/whatsnew/1.8.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/1.9.html
+++ b/iris/docs/v2.1/whatsnew/1.9.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/2.0.html
+++ b/iris/docs/v2.1/whatsnew/2.0.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/2.0a0.html
+++ b/iris/docs/v2.1/whatsnew/2.0a0.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/iris/docs/v2.1/whatsnew/2.1.html
+++ b/iris/docs/v2.1/whatsnew/2.1.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whatsnew/index.html
+++ b/iris/docs/v2.1/whatsnew/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whitepapers/change_management.html
+++ b/iris/docs/v2.1/whitepapers/change_management.html
@@ -21,7 +21,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whitepapers/index.html
+++ b/iris/docs/v2.1/whitepapers/index.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whitepapers/missing_data_handling.html
+++ b/iris/docs/v2.1/whitepapers/missing_data_handling.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/iris/docs/v2.1/whitepapers/um_files_loading.html
+++ b/iris/docs/v2.1/whitepapers/um_files_loading.html
@@ -23,7 +23,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="../_static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../_static/favicon-16x16.png">

--- a/shared_assets/010d7fd5cb2972549f673df5348e165f05cc2b29291cd20e3f6e56e5-nimrod.html
+++ b/shared_assets/010d7fd5cb2972549f673df5348e165f05cc2b29291cd20e3f6e56e5-nimrod.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/05d84981b9636d7a1c0714f48ddd8abdd3378314ca0b5eb6c9ff3f12-trajectory.html
+++ b/shared_assets/05d84981b9636d7a1c0714f48ddd8abdd3378314ca0b5eb6c9ff3f12-trajectory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/091b79c0be44cadda51c5a03a0f5656e238f7c0273b9dfd280b23589-coord_categorisation.html
+++ b/shared_assets/091b79c0be44cadda51c5a03a0f5656e238f7c0273b9dfd280b23589-coord_categorisation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/0c6721553028db7529b6ba53bd4e07c86a81f6d9127be8933ddd8b03-installing.html
+++ b/shared_assets/0c6721553028db7529b6ba53bd4e07c86a81f6d9127be8933ddd8b03-installing.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/0d3b9c1bc84157d1b152e5290095ab5438a759d5fef7331e0cefef48-development_workflow.html
+++ b/shared_assets/0d3b9c1bc84157d1b152e5290095ab5438a759d5fef7331e0cefef48-development_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/0d6c1bbc6e349034204ab107842d9a4c8c8f1a5bd61116866bbca632-dot.html
+++ b/shared_assets/0d6c1bbc6e349034204ab107842d9a4c8c8f1a5bd61116866bbca632-dot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/0e51853836d4940f8cad9d2ecefceb179b557bff558fdd542090d0a8-name_loaders.html
+++ b/shared_assets/0e51853836d4940f8cad9d2ecefceb179b557bff558fdd542090d0a8-name_loaders.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/0f81d18ff49e6595df5363369f0d84a55c8871c86cfc7824c49676bf-git_intro.html
+++ b/shared_assets/0f81d18ff49e6595df5363369f0d84a55c8871c86cfc7824c49676bf-git_intro.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/10fdc699176671457c9a0aaf7e4df8d5633866a7af464463705f0792-configure_git.html
+++ b/shared_assets/10fdc699176671457c9a0aaf7e4df8d5633866a7af464463705f0792-configure_git.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/114766e4cc1cec6f7db3d2ffa208d37ad604953e5dd3f0e76f30f10d-polar_stereo.html
+++ b/shared_assets/114766e4cc1cec6f7db3d2ffa208d37ad604953e5dd3f0e76f30f10d-polar_stereo.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/16cf69b073d6228384f5e91972679a1976d7d97ed2f8e16270dc5278-gallery.html
+++ b/shared_assets/16cf69b073d6228384f5e91972679a1976d7d97ed2f8e16270dc5278-gallery.html
@@ -30,7 +30,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/1a54ac6ba5d41ec822271a85245afb1d0f91d46c78f7a6af47b80b01-um_cf_map.html
+++ b/shared_assets/1a54ac6ba5d41ec822271a85245afb1d0f91d46c78f7a6af47b80b01-um_cf_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/1c3ec121a31dd5baf3246bc540114af789418b129b3b105613f5b89f-SOI_filtering.html
+++ b/shared_assets/1c3ec121a31dd5baf3246bc540114af789418b129b3b105613f5b89f-SOI_filtering.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/1d469db65a754e34da93694ff750776459118181cc19af159d2978fe-navigating_a_cube.html
+++ b/shared_assets/1d469db65a754e34da93694ff750776459118181cc19af159d2978fe-navigating_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/1eb1e95ecc6069efece202d9ef362d9a02e16f17d0375a2479847941-um_files_loading.html
+++ b/shared_assets/1eb1e95ecc6069efece202d9ef362d9a02e16f17d0375a2479847941-um_files_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/1fc243b8352d3c1f455c05feb2c8f51286edafddedb721df4077f681-index.html
+++ b/shared_assets/1fc243b8352d3c1f455c05feb2c8f51286edafddedb721df4077f681-index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/20f0f6ce2faa49c968ab1352d09df6772c5a39a8ba75476be0919e16-grib.html
+++ b/shared_assets/20f0f6ce2faa49c968ab1352d09df6772c5a39a8ba75476be0919e16-grib.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/24a32ffc50582b7eba1afd2e20b3feb715c1840ca979bd386cf6844e-um.html
+++ b/shared_assets/24a32ffc50582b7eba1afd2e20b3feb715c1840ca979bd386cf6844e-um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/259976487421d0fecf553bd0223ee4e35eccda1f25211a90521b8ddf-fieldsfile.html
+++ b/shared_assets/259976487421d0fecf553bd0223ee4e35eccda1f25211a90521b8ddf-fieldsfile.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/26f74c04dfe7a3687d6a9afe0d1e50f073b229957ede44c9a6e08c52-subsetting_a_cube.html
+++ b/shared_assets/26f74c04dfe7a3687d6a9afe0d1e50f073b229957ede44c9a6e08c52-subsetting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/27764f36a187cbf46645694846ef0473b7b1e1d182ba42f271f21a1d-end_of_userguide.html
+++ b/shared_assets/27764f36a187cbf46645694846ef0473b7b1e1d182ba42f271f21a1d-end_of_userguide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/288a5eb03ed332029c6c5cffc258cb7e652159598d3acc5ed3d89c53-forking_hell.html
+++ b/shared_assets/288a5eb03ed332029c6c5cffc258cb7e652159598d3acc5ed3d89c53-forking_hell.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/2e1995177e6d3137dac74b84207868d51f246df0250a8771b28ca27d-contents.html
+++ b/shared_assets/2e1995177e6d3137dac74b84207868d51f246df0250a8771b28ca27d-contents.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/2feba35c092c7a1d572edbab61a0a534ada21b849f677c2ae633f33b-cf.html
+++ b/shared_assets/2feba35c092c7a1d572edbab61a0a534ada21b849f677c2ae633f33b-cf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/3180540d7047ce66eec626e67cbc444159351566fb9fb2a81640e0c1-docstrings.html
+++ b/shared_assets/3180540d7047ce66eec626e67cbc444159351566fb9fb2a81640e0c1-docstrings.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/33839d236b457c2b592900c4305e08443d088fda48a38e3c4881443f-pulls.html
+++ b/shared_assets/33839d236b457c2b592900c4305e08443d088fda48a38e3c4881443f-pulls.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/369c97b7a30f07c4736ec25c539a42f2502c0c789e383dce8bc7f916-projections_and_annotations.html
+++ b/shared_assets/369c97b7a30f07c4736ec25c539a42f2502c0c789e383dce8bc7f916-projections_and_annotations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/36e6b69b93ef751f0b9da62ef84de0da9d3f1d62a462e6382363b586-search.html
+++ b/shared_assets/36e6b69b93ef751f0b9da62ef84de0da9d3f1d62a462e6382363b586-search.html
@@ -37,7 +37,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
 
   </head>

--- a/shared_assets/3a41d8f0b71e1deb18eb049e03fa61804e13fe56fdbbfcfd20dbe14a-cartography.html
+++ b/shared_assets/3a41d8f0b71e1deb18eb049e03fa61804e13fe56fdbbfcfd20dbe14a-cartography.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/3a882ee3f373fba184d57ab4cf6d02b4c2c11d0684e0eafdd5ec918c-anomaly_log_colouring.html
+++ b/shared_assets/3a882ee3f373fba184d57ab4cf6d02b4c2c11d0684e0eafdd5ec918c-anomaly_log_colouring.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/3ca960bc0bd58994606af13bb788055ce4a60c23e5e7eeaa02965106-citation.html
+++ b/shared_assets/3ca960bc0bd58994606af13bb788055ce4a60c23e5e7eeaa02965106-citation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/3e91999724524972db262b7521ec3c8a06951c4dd2346dfecd39b742-name.html
+++ b/shared_assets/3e91999724524972db262b7521ec3c8a06951c4dd2346dfecd39b742-name.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/405e5057196ceb4f28d6a719b352ed4bb7205cc47699318294f5bb91-cube.html
+++ b/shared_assets/405e5057196ceb4f28d6a719b352ed4bb7205cc47699318294f5bb91-cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/42fb747bb9a550780fb74dac76cc77b745670c073a4d01c29a9bdb69-pandas.html
+++ b/shared_assets/42fb747bb9a550780fb74dac76cc77b745670c073a4d01c29a9bdb69-pandas.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/46352a952ba60d364ece3a246070827fb0d49aeaaa41fb6f01b1d2b1-rotated_pole_mapping.html
+++ b/shared_assets/46352a952ba60d364ece3a246070827fb0d49aeaaa41fb6f01b1d2b1-rotated_pole_mapping.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/48e30e06082b9c1c009313fd9a0d11dac0aa0472c3bc405e6dcdba8f-quickplot.html
+++ b/shared_assets/48e30e06082b9c1c009313fd9a0d11dac0aa0472c3bc405e6dcdba8f-quickplot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/4c869c3cc2d41c89c1592f2d30ec2a3da2e35537dd433de1ddd91b64-aux_factory.html
+++ b/shared_assets/4c869c3cc2d41c89c1592f2d30ec2a3da2e35537dd433de1ddd91b64-aux_factory.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/4ef0feac126212659d0f34d1dd1a8bd966be94fb90ab430401c58d28-maths.html
+++ b/shared_assets/4ef0feac126212659d0f34d1dd1a8bd966be94fb90ab430401c58d28-maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/4fdce5f44434b5b7868069633543d90d56e1cca8a6cd93b4ddebfbcb-coord_systems.html
+++ b/shared_assets/4fdce5f44434b5b7868069633543d90d56e1cca8a6cd93b4ddebfbcb-coord_systems.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/502cd944f0933cb4a04479edd50d32477e84fa6e6074ca798ec4a297-index.html
+++ b/shared_assets/502cd944f0933cb4a04479edd50d32477e84fa6e6074ca798ec4a297-index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5034a24f76a2659607fab7a137b1385faf515c558ab947c2ded4230f-ff.html
+++ b/shared_assets/5034a24f76a2659607fab7a137b1385faf515c558ab947c2ded4230f-ff.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/53b07801c59cc18c2036fc0ddb61eecf7753ec6ece91aeacf66ac379-um.html
+++ b/shared_assets/53b07801c59cc18c2036fc0ddb61eecf7753ec6ece91aeacf66ac379-um.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/53c0e3e6adabc7f62e68d402e4b7096837c7e7f346d8e1494a56a837-fileformats.html
+++ b/shared_assets/53c0e3e6adabc7f62e68d402e4b7096837c7e7f346d8e1494a56a837-fileformats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/548cfa956b8e838e3c77a75bee0eef68fd5e260db727a9eef51d91ca-animate.html
+++ b/shared_assets/548cfa956b8e838e3c77a75bee0eef68fd5e260db727a9eef51d91ca-animate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/54a1f640f3cf756f4ce3544b74485f16c7e991099c639015f2e335e0-1.3.html
+++ b/shared_assets/54a1f640f3cf756f4ce3544b74485f16c7e991099c639015f2e335e0-1.3.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/57cabf388dbd83105bf87f66d091b6a282ca26161cc334178fe746a8-std_names.html
+++ b/shared_assets/57cabf388dbd83105bf87f66d091b6a282ca26161cc334178fe746a8-std_names.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/582e5854c3cf350f0b8813cdc1bf4f6953e6fcc8beb8376adf0be065-index.html
+++ b/shared_assets/582e5854c3cf350f0b8813cdc1bf4f6953e6fcc8beb8376adf0be065-index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5a7eac03abc7087611c3bc85eb0fdc896a1ed616039b4b9cb6183850-iris_cubes.html
+++ b/shared_assets/5a7eac03abc7087611c3bc85eb0fdc896a1ed616039b4b9cb6183850-iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5cde7038da9cdcd5b3fc3fb4c683e0b20fbcaf11da80ca271bec23e7-equalise_cubes.html
+++ b/shared_assets/5cde7038da9cdcd5b3fc3fb4c683e0b20fbcaf11da80ca271bec23e7-equalise_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5dec50eac75470cfe3fb7cfda0813ada48419ccd6f19028cfe59a0b2-time.html
+++ b/shared_assets/5dec50eac75470cfe3fb7cfda0813ada48419ccd6f19028cfe59a0b2-time.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5e938265b6e4df7a3c90c5100077fbc25e5f9288c3bfa2c21f830e1b-index.html
+++ b/shared_assets/5e938265b6e4df7a3c90c5100077fbc25e5f9288c3bfa2c21f830e1b-index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5ed0d13013ac84a44c294031427638d454b1d5c668391e11d61ffab0-io.html
+++ b/shared_assets/5ed0d13013ac84a44c294031427638d454b1d5c668391e11d61ffab0-io.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/5feac4dee2b5b371208e098f1c8239591f0f2da6db5ed16bb727e1f5-saving_iris_cubes.html
+++ b/shared_assets/5feac4dee2b5b371208e098f1c8239591f0f2da6db5ed16bb727e1f5-saving_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/64d1147ac7add72d80974127f676e9f92e521761555bb1ab336d75fb-deriving_phenomena.html
+++ b/shared_assets/64d1147ac7add72d80974127f676e9f92e521761555bb1ab336d75fb-deriving_phenomena.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/69b03503cf2d0418a4224569cdb14a4799f70cafb238d913ee949404-load_rules.html
+++ b/shared_assets/69b03503cf2d0418a4224569cdb14a4799f70cafb238d913ee949404-load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/6cfff9fac33b22b79b46206ecdbf5f8f34c4cffd8e0397201d7c92df-1.1.html
+++ b/shared_assets/6cfff9fac33b22b79b46206ecdbf5f8f34c4cffd8e0397201d7c92df-1.1.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/6fb2fd79c7a5e311228e3d1ac94d31fca9392d5772e1ac22bde8f0b7-patching.html
+++ b/shared_assets/6fb2fd79c7a5e311228e3d1ac94d31fca9392d5772e1ac22bde8f0b7-patching.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/778174fe2e879125691c295102377a5c8a955748c83cd1972b39b86b-plotting_a_cube.html
+++ b/shared_assets/778174fe2e879125691c295102377a5c8a955748c83cd1972b39b86b-plotting_a_cube.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/77a107c1aac08cd5ba771950528b6b88dda50164c458d4c7e0259739-index.html
+++ b/shared_assets/77a107c1aac08cd5ba771950528b6b88dda50164c458d4c7e0259739-index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/77dc3c9e817b560f4a5782f53df2c802f52c793ce85ff085c448b143-git_resources.html
+++ b/shared_assets/77dc3c9e817b560f4a5782f53df2c802f52c793ce85ff085c448b143-git_resources.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/79f99cc141f00d49a16f98a235d4a3ab27d931d532550d0c36b6c827-rules.html
+++ b/shared_assets/79f99cc141f00d49a16f98a235d4a3ab27d931d532550d0c36b6c827-rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/7ea0a81c63e29354eb36c3de1b0864126b9c4a6157e58dc16aa4f1af-git_install.html
+++ b/shared_assets/7ea0a81c63e29354eb36c3de1b0864126b9c4a6157e58dc16aa4f1af-git_install.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/7ed71e403cc86226631f76ecc0ae479facf8ac7e80ec2b2b7e73407c-hovmoller.html
+++ b/shared_assets/7ed71e403cc86226631f76ecc0ae479facf8ac7e80ec2b2b7e73407c-hovmoller.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/7fe7c79170a4b253000d280de14598651bceb9b2a4716c993b20973c-global_map.html
+++ b/shared_assets/7fe7c79170a4b253000d280de14598651bceb9b2a4716c993b20973c-global_map.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/81b32ea225d0ce2b91aef6426f3cee8d86ed3e8bb7ed1176a7a04654-index.html
+++ b/shared_assets/81b32ea225d0ce2b91aef6426f3cee8d86ed3e8bb7ed1176a7a04654-index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/82db6ae1ca9f24d99eaf869da736f276bab0a7f6f8b9554c11a22f37-interpolate.html
+++ b/shared_assets/82db6ae1ca9f24d99eaf869da736f276bab0a7f6f8b9554c11a22f37-interpolate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/8429dcb6240de113c773dc5a21ec52049ae6da6c9aee9da569a4cda5-1.9.html
+++ b/shared_assets/8429dcb6240de113c773dc5a21ec52049ae6da6c9aee9da569a4cda5-1.9.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/85d5a11b3348dc7e5fdc98329554544067928ea15637c50a2a86512b-grib_save_rules.html
+++ b/shared_assets/85d5a11b3348dc7e5fdc98329554544067928ea15637c50a2a86512b-grib_save_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/8b8cd02837fe971bcdadad3979b1964a152ef40a3594c1fad9e9e6b7-proxy.html
+++ b/shared_assets/8b8cd02837fe971bcdadad3979b1964a152ef40a3594c1fad9e9e6b7-proxy.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/8c1d24b06256ec885f46efb5b943d0a923e680c50add3a9dfcc4ea24-concatenate.html
+++ b/shared_assets/8c1d24b06256ec885f46efb5b943d0a923e680c50add3a9dfcc4ea24-concatenate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/911e217febd2bbc2b54180fdf1712908994136adf5d6df51cd528895-cube_statistics.html
+++ b/shared_assets/911e217febd2bbc2b54180fdf1712908994136adf5d6df51cd528895-cube_statistics.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/98b00023cc9b5cc313702b2488aab59c2df025f2e3ee9de92d5069fc-lineplot_with_legend.html
+++ b/shared_assets/98b00023cc9b5cc313702b2488aab59c2df025f2e3ee9de92d5069fc-lineplot_with_legend.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/9c77992dab98fb10979e2249ce2bef41ebc0225124f5d59a24a256c9-symbols.html
+++ b/shared_assets/9c77992dab98fb10979e2249ce2bef41ebc0225124f5d59a24a256c9-symbols.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/9cfcfd5baa6f1cb979886cd49baaa04f059620ea88767fb653fb3e77-unit.html
+++ b/shared_assets/9cfcfd5baa6f1cb979886cd49baaa04f059620ea88767fb653fb3e77-unit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/9d3ad673bcb11d0ea7940e294c24a74ff9274220b4c703ff0ceda51c-rest_guide.html
+++ b/shared_assets/9d3ad673bcb11d0ea7940e294c24a74ff9274220b4c703ff0ceda51c-rest_guide.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/9ef891d3c595a3520a2af27aed43698995024daa484fac47aa9240e7-iris.html
+++ b/shared_assets/9ef891d3c595a3520a2af27aed43698995024daa484fac47aa9240e7-iris.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/a3cb9062f9327026eb6c66321299add6c047229a1a0ac799305f123d-interpolation_and_regridding.html
+++ b/shared_assets/a3cb9062f9327026eb6c66321299add6c047229a1a0ac799305f123d-interpolation_and_regridding.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/a5681e057f6a44556dd92c8e24d840ef8b668d3ef67e38c92b3bdf7b-whats_new_contributions.html
+++ b/shared_assets/a5681e057f6a44556dd92c8e24d840ef8b668d3ef67e38c92b3bdf7b-whats_new_contributions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/a6b892ce2db587e368ed74bf5c80170d4f54eddd4de4ddbc4b6463a7-TEC.html
+++ b/shared_assets/a6b892ce2db587e368ed74bf5c80170d4f54eddd4de4ddbc4b6463a7-TEC.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/a8247930fc151151df6994f959ba90f8847c7f04a38114ce85265fbb-ugrid.html
+++ b/shared_assets/a8247930fc151151df6994f959ba90f8847c7f04a38114ce85265fbb-ugrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/abb96f3807d172b1a56b5b684f9271849609ad9a331be0fc3dfddc42-tests.html
+++ b/shared_assets/abb96f3807d172b1a56b5b684f9271849609ad9a331be0fc3dfddc42-tests.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/acad76e1da9c554f83e502ba22cb7ab6cd300aef4fbc8eea60680633-loading_iris_cubes.html
+++ b/shared_assets/acad76e1da9c554f83e502ba22cb7ab6cd300aef4fbc8eea60680633-loading_iris_cubes.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ad1fd844b209e21025c79e91705c37e93a710b61c4ac3f82f01cd6b8-1.0.html
+++ b/shared_assets/ad1fd844b209e21025c79e91705c37e93a710b61c4ac3f82f01cd6b8-1.0.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/af5792eb06cd10faae95681902a303d8174da90a7b3a60f4d0f7c336-exceptions.html
+++ b/shared_assets/af5792eb06cd10faae95681902a303d8174da90a7b3a60f4d0f7c336-exceptions.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/afb36f38e62e641ee9e0ebada2bf32a136d6db93c9cad6d3077b28e6-COP_maps.html
+++ b/shared_assets/afb36f38e62e641ee9e0ebada2bf32a136d6db93c9cad6d3077b28e6-COP_maps.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b0193c1f74bc4be54342023d3737f90d96c6008a7204d1a642976463-1.5.html
+++ b/shared_assets/b0193c1f74bc4be54342023d3737f90d96c6008a7204d1a642976463-1.5.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b0a180460a8075778d48fcc5957a7379a7d6f62d5309e0f4dc5a6250-analysis.html
+++ b/shared_assets/b0a180460a8075778d48fcc5957a7379a7d6f62d5309e0f4dc5a6250-analysis.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b1054deae30c16c8e40d6d4c742bb77f813f112899d74d2270bf3c52-geometry.html
+++ b/shared_assets/b1054deae30c16c8e40d6d4c742bb77f813f112899d74d2270bf3c52-geometry.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b1263ee513e1babf490b19ccf7ed08001d3f11d923cabd75941983c8-iterate.html
+++ b/shared_assets/b1263ee513e1babf490b19ccf7ed08001d3f11d923cabd75941983c8-iterate.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b1d9b6db9992588c3b1e21a8e9e971951efdbd7073143a436b834b11-lagged_ensemble.html
+++ b/shared_assets/b1d9b6db9992588c3b1e21a8e9e971951efdbd7073143a436b834b11-lagged_ensemble.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b429fa7f418231d947e9d8f7a274942fad1ce0207ecfbc8aa3bfca0b-regrid.html
+++ b/shared_assets/b429fa7f418231d947e9d8f7a274942fad1ce0207ecfbc8aa3bfca0b-regrid.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b486a8d561e471c12cd1d91b2fe7aa5844ff8694a85f12e47ae37696-index.html
+++ b/shared_assets/b486a8d561e471c12cd1d91b2fe7aa5844ff8694a85f12e47ae37696-index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b772815e780752fc8f17b8f20a898fb4c5abbf5a14c170602d3ad7d2-cross_section.html
+++ b/shared_assets/b772815e780752fc8f17b8f20a898fb4c5abbf5a14c170602d3ad7d2-cross_section.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b8a29fd5430baa907869a58d7ba10080e906b7717c7f8721f8c1a105-nimrod_load_rules.html
+++ b/shared_assets/b8a29fd5430baa907869a58d7ba10080e906b7717c7f8721f8c1a105-nimrod_load_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/b917e60da254b960e9032640c9d62efcdf6d3ec5168e6fd2ef6e9bba-1.7.html
+++ b/shared_assets/b917e60da254b960e9032640c9d62efcdf6d3ec5168e6fd2ef6e9bba-1.7.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/bc64c1f87b5ba1342eb12f1461a62ccf39b18397372b9caf4828bcfa-atlantic_profiles.html
+++ b/shared_assets/bc64c1f87b5ba1342eb12f1461a62ccf39b18397372b9caf4828bcfa-atlantic_profiles.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/c019d16755271bb41302d630f8707bd5db5c8d3d8b7641a81f9f3a47-index.html
+++ b/shared_assets/c019d16755271bb41302d630f8707bd5db5c8d3d8b7641a81f9f3a47-index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/c0961ff076f9b1b4418b8e8db9e8acd8f44e028b648bb871c21f9e73-index.html
+++ b/shared_assets/c0961ff076f9b1b4418b8e8db9e8acd8f44e028b648bb871c21f9e73-index.html
@@ -32,7 +32,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/c0b089f0ca201e2f37e49a64caff85016ee16a9f1b3b7e74d34e75e5-calculus.html
+++ b/shared_assets/c0b089f0ca201e2f37e49a64caff85016ee16a9f1b3b7e74d34e75e5-calculus.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/c273854ab82710d083d10f1485423f1d52d25e94861badec3224d6ed-experimental.html
+++ b/shared_assets/c273854ab82710d083d10f1485423f1d52d25e94861badec3224d6ed-experimental.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/c7797cb5e672b9331d12e798b89daf0b1cda18dab9668199214833ca-util.html
+++ b/shared_assets/c7797cb5e672b9331d12e798b89daf0b1cda18dab9668199214833ca-util.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ce0aa50e7f1dbcfffc6a4869f0c5b76c7feb51088a4d3993b087ef57-stats.html
+++ b/shared_assets/ce0aa50e7f1dbcfffc6a4869f0c5b76c7feb51088a4d3993b087ef57-stats.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ce2e134d8b84472cb9b1a9604058137b79d2048d6dd272b2d39b166c-1.4.html
+++ b/shared_assets/ce2e134d8b84472cb9b1a9604058137b79d2048d6dd272b2d39b166c-1.4.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d1b3b0fccf0a712ca2b52c57e2dd2eb2b02444b406da2d8651b4c4ac-index.html
+++ b/shared_assets/d1b3b0fccf0a712ca2b52c57e2dd2eb2b02444b406da2d8651b4c4ac-index.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d1e9f250b0fd4aed6dd926f6a0d740f7b827e7a29688e87f970f4684-raster.html
+++ b/shared_assets/d1e9f250b0fd4aed6dd926f6a0d740f7b827e7a29688e87f970f4684-raster.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d4b90bfebe004f8df16fa9bc88736e8a95ac179f6c6a31be20ce55c2-cube_maths.html
+++ b/shared_assets/d4b90bfebe004f8df16fa9bc88736e8a95ac179f6c6a31be20ce55c2-cube_maths.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d5de56aab88d6c0692aa642bade2bf2f5c5ca5847a99da3fd3d9c62e-orca_projection.html
+++ b/shared_assets/d5de56aab88d6c0692aa642bade2bf2f5c5ca5847a99da3fd3d9c62e-orca_projection.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d68a18e9f0070f9d813e7b4e67ac0bbe23adc6c7679c49a81b4b9ee7-1.2.html
+++ b/shared_assets/d68a18e9f0070f9d813e7b4e67ac0bbe23adc6c7679c49a81b4b9ee7-1.2.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/d6f3caabcb589a00b563e25ae937b888565b6a4e413d42fb5cdbe8cb-abf.html
+++ b/shared_assets/d6f3caabcb589a00b563e25ae937b888565b6a4e413d42fb5cdbe8cb-abf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/dfda8e7cf5b82ffe992f4f1fdbacf78db0b66871088dabe6b0bd3fad-format_picker.html
+++ b/shared_assets/dfda8e7cf5b82ffe992f4f1fdbacf78db0b66871088dabe6b0bd3fad-format_picker.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e08236b0a48b4565b1a6cdf08bc853b7728f18a2ad614579b8c17f46-git_development.html
+++ b/shared_assets/e08236b0a48b4565b1a6cdf08bc853b7728f18a2ad614579b8c17f46-git_development.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e0fdd4b2b16394e0592da444dda36d61d2366023ecd48fd0a5ad0532-merge_and_concat.html
+++ b/shared_assets/e0fdd4b2b16394e0592da444dda36d61d2366023ecd48fd0a5ad0532-merge_and_concat.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e263b29d41e5c6f19c53f7d8fb495fce96515ecfd213283054e7f9b7-following_latest.html
+++ b/shared_assets/e263b29d41e5c6f19c53f7d8fb495fce96515ecfd213283054e7f9b7-following_latest.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e36b5d206be2c9bd804d7fc9dd19af926ea6e6d17240ab7aa9e35414-genindex.html
+++ b/shared_assets/e36b5d206be2c9bd804d7fc9dd19af926ea6e6d17240ab7aa9e35414-genindex.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e77fe4468785f5713304b8de6d4fee27479e5b89fa81fb3ef0208754-plot.html
+++ b/shared_assets/e77fe4468785f5713304b8de6d4fee27479e5b89fa81fb3ef0208754-plot.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e8b4415a3265cc2c37fc041e6005b4c8ad87c592e66ba91c244db4f2-regrid_conservative.html
+++ b/shared_assets/e8b4415a3265cc2c37fc041e6005b4c8ad87c592e66ba91c244db4f2-regrid_conservative.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/e916f364a3d6b07763b48da2f23c9056b70198b6f5ab9127318d8475-pp_packing.html
+++ b/shared_assets/e916f364a3d6b07763b48da2f23c9056b70198b6f5ab9127318d8475-pp_packing.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ea19702d98635fc94a4211225b98c8d594df82c8d4092fc2e8d76250-copyright.html
+++ b/shared_assets/ea19702d98635fc94a4211225b98c8d594df82c8d4092fc2e8d76250-copyright.html
@@ -31,7 +31,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ea6ee4fd5d154af4d4abf4709cd06d38c7a59fc9fb9bc19f77ebcc1a-set_up_fork.html
+++ b/shared_assets/ea6ee4fd5d154af4d4abf4709cd06d38c7a59fc9fb9bc19f77ebcc1a-set_up_fork.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ecd5ab2746cc6721897cc390606d4d401f6e9d6aaaaeb7c916c29c71-polynomial_fit.html
+++ b/shared_assets/ecd5ab2746cc6721897cc390606d4d401f6e9d6aaaaeb7c916c29c71-polynomial_fit.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ee7dae45e9637721c0b835b581a4478e67fdf19c3c84421167df6909-custom_aggregation.html
+++ b/shared_assets/ee7dae45e9637721c0b835b581a4478e67fdf19c3c84421167df6909-custom_aggregation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f023904b7904333095c8dc24ce52922526ffc81d4e320a5b9789adaa-custom_file_loading.html
+++ b/shared_assets/f023904b7904333095c8dc24ce52922526ffc81d4e320a5b9789adaa-custom_file_loading.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f035679ea9e924de470dc5bc613ff1fb471d6811cf5c1f3ba84f5b1a-grib_phenom_translation.html
+++ b/shared_assets/f035679ea9e924de470dc5bc613ff1fb471d6811cf5c1f3ba84f5b1a-grib_phenom_translation.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f1b548ff4d31852493c924a8cf9239ce9937a9ab87e0ad29515d19c4-config.html
+++ b/shared_assets/f1b548ff4d31852493c924a8cf9239ce9937a9ab87e0ad29515d19c4-config.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f3288e177452e9aebeb664d25929f1335dcb5d04b55debcaa67a457a-1.6.html
+++ b/shared_assets/f3288e177452e9aebeb664d25929f1335dcb5d04b55debcaa67a457a-1.6.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f4053b975f6c2d785797f83303a52aedeee9c9df0c46a6fc7eda8398-netcdf.html
+++ b/shared_assets/f4053b975f6c2d785797f83303a52aedeee9c9df0c46a6fc7eda8398-netcdf.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f508455b96dce1664410973ac6ad277e8898944fb40c8a53f3a0aa65-pp.html
+++ b/shared_assets/f508455b96dce1664410973ac6ad277e8898944fb40c8a53f3a0aa65-pp.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f65834e758000afc5e632c16481de9f33a0566a25b3aeb5366099ff3-1.8.html
+++ b/shared_assets/f65834e758000afc5e632c16481de9f33a0566a25b3aeb5366099ff3-1.8.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f6b64d6c5900f4273c1e7edb393500d33a82e4ef34c9bce027e5282c-coords.html
+++ b/shared_assets/f6b64d6c5900f4273c1e7edb393500d33a82e4ef34c9bce027e5282c-coords.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/f736fd15babf3be2c66094b6a9d6d4756238366c32466f662fcc2d3d-palette.html
+++ b/shared_assets/f736fd15babf3be2c66094b6a9d6d4756238366c32466f662fcc2d3d-palette.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/fd255d35932f21431d7699facb277a5c6dbe291a6a749fb417fdfae3-maintainer_workflow.html
+++ b/shared_assets/fd255d35932f21431d7699facb277a5c6dbe291a6a749fb417fdfae3-maintainer_workflow.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/fe10e9ca945473e1f4742ec0f494496e746305c7733924664717e838-pp_rules.html
+++ b/shared_assets/fe10e9ca945473e1f4742ec0f494496e746305c7733924664717e838-pp_rules.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../../../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>

--- a/shared_assets/ff602fab15b98d1627c2a615c6f0396f9302c6b6e7efd6035738cd1a-deprecations.html
+++ b/shared_assets/ff602fab15b98d1627c2a615c6f0396f9302c6b6e7efd6035738cd1a-deprecations.html
@@ -33,7 +33,7 @@
     <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE"> 
 
     <link rel="stylesheet" href="../_static/style.css" type="text/css" />
-    <script type="text/javascript" src="http://docs.python.org/2/_static/copybutton.js"></script>
+    <script type="text/javascript" src="https://docs.python.org/2/_static/copybutton.js"></script>
 
   </head>
   <body>


### PR DESCRIPTION
https://github.com/SciTools/iris/issues/3057
Re-enable copybutton by using https instead of http.

```bash
find ./ -type f -exec sed -i 's#http://docs.python.org/2/_static/copybutton.js#https://docs.python.org/2/_static/copybutton.js#g' {} \;
```