### PR TITLE
Scitools licensing guide

### DIFF
--- a/documents/scitools_licensing.md
+++ b/documents/scitools_licensing.md
@@ -11,11 +11,19 @@ license.
 ## Copyright
 
 All SciTools projects operate a shared ownership model as specified
-in the SciTools CLA. The copyright statement is:
+in the [SciTools CLA](https://scitools.org.uk/cla/v4).
+The copyright statement is:
 
 ```
-Copyright <start year> (- <end year>) <project> developers
+Copyright (C) <start year>(-<end year>) <project> contributors
 ```
+
+For example:
+
+```
+Copyright (C) 2010-2018 Iris contributors
+```
+
 
 ## Source preamble
 
@@ -23,9 +31,9 @@ All non-trivial source files in a SciTools repository must reference the
 license of the repository. The wording of the preamble should be:
 
 ```
-# Copyright <project> developers
-
-# This file is part of <project> and is released under a BSD 3-clause license.
+# Copyright (C) <project> contributors
+#
+# This file is part of <project> and is released under the <OSI license> license.
 # See LICENSE in the root of the repository for full licensing details.
 ```
 
@@ -40,7 +48,10 @@ The full text of a BSD 3-clause LICENSE file should be:
 ```
 BSD 3-Clause License
 
-Copyright 2010 - 20?? <project> developers
+Copyright (C) <YEAR_START>-<YEAR_END> <project> contributors
+
+See "Credits, copyright and license" in README.<ext> for full credits
+<(if appropriate) and any exceptions to the following terms>.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -68,10 +79,46 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-The license must be unmodified except in the situation where
-vendored / third-party tools have been packaged into the repository.
-As always, due care with licensing *MUST* be taken when vendoring in this way.
-Supplimentary license details should be documented at the end of the LICENSE
-file. An example of doing so can be seen in the numpy codebase.
 
+In the situation where vendored / third-party tools have been packaged
+into the repository, full terms should be documented in the License section of
+the README.
+As always, due care with licensing *MUST* be taken when vendoring in this way.
+
+
+## Readme credits and license section
+
+All repositories should include a "Credits, copyright and License"
+section in the README.[md|rst|txt].
+
+The Credits section should be used to document significant institutional
+development of the project and to provide a link
+pointing to the GitHub contributors list.
+
+The Copyright and License section should re-iterate the copyright found
+in the LICENSE file.
+
+For example, Iris's README.md may include the following:
+
+```
+
+## Credits, copyright and license
+
+Iris is developed collaboratively under the SciTools umberella.
+
+A full list of code contributors ("Iris contributors") can be found at
+https://github.com/SciTools/iris/graphs/contributors.
+
+Code is just one of many ways of positively contributing to Iris, please see
+our [contributing guide](.github/CONTRIBUTING.md) for more details on how
+you can get involved.
+
+Iris is released under a LGPL license with a shared copyright model.
+See [LICENSE](LICENSE) for full terms.
+
+The Met Office has made a significant contribution to the
+development, maintenance and support of this library.
+All Met Office contributions are copyright on behalf of the British Crown.
+
+```
 

--- a/documents/scitools_licensing.md
+++ b/documents/scitools_licensing.md
@@ -21,7 +21,7 @@ Copyright © <start year>(-<end year>) <project> contributors
 For example:
 
 ```
-Copyright © 2010-2018 Iris contributors
+Copyright 2010-2018 Iris contributors
 ```
 
 
@@ -31,7 +31,7 @@ All non-trivial source files in a SciTools repository must reference the
 license of the repository. The wording of the preamble should be:
 
 ```
-# Copyright © <project> contributors
+# Copyright <project> contributors
 #
 # This file is part of <project> and is released under the <OSI license> license.
 # See LICENSE in the root of the repository for full licensing details.
@@ -48,7 +48,7 @@ The full text of a BSD 3-clause LICENSE file should be:
 ```
 BSD 3-Clause License
 
-Copyright © <YEAR_START>-<YEAR_END> <project> contributors
+Copyright <YEAR_START>-<YEAR_END> <project> contributors
 
 See "Credits, copyright and license" in README.<ext> for full credits
 <(if appropriate) and any exceptions to the following terms>.
@@ -116,8 +116,8 @@ you can get involved.
 Iris is released under a LGPL license with a shared copyright model.
 See [LICENSE](LICENSE) for full terms.
 
-The Met Office has made a significant contribution to the
-development, maintenance and support of this library.
+The [Met Office](https://metoffice.gov.uk) has made a significant
+contribution to the development, maintenance and support of this library.
 All Met Office contributions are copyright on behalf of the British Crown.
 
 ```

--- a/documents/scitools_licensing.md
+++ b/documents/scitools_licensing.md
@@ -1,0 +1,77 @@
+# SciTools Projects
+
+## Licensing
+
+All projects under the SciTools[-incubator] GitHub organisations are to be
+developed in the open (i.e. via small pull requests which are open to
+public review) and released under an OSI (Open Source Initiative) approved
+license.
+
+
+## Copyright
+
+All SciTools projects operate a shared ownership model as specified
+in the SciTools CLA. The copyright statement is:
+
+```
+Copyright <start year> (- <end year>) <project> developers
+```
+
+## Source preamble
+
+All non-trivial source files in a SciTools repository must reference the
+license of the repository. The wording of the preamble should be:
+
+```
+# Copyright <project> developers
+
+# This file is part of <project> and is released under a BSD 3-clause license.
+# See LICENSE in the root of the repository for full licensing details.
+```
+
+**Note:** start and end dates are *not* required in the source preamble
+
+
+## Default license
+
+The default license for all SciTools projects is the BSD 3-clause license. 
+The full text of a BSD 3-clause LICENSE file should be:
+
+```
+BSD 3-Clause License
+
+Copyright 2010 - 20?? <project> developers
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+The license must be unmodified except in the situation where
+vendored / third-party tools have been packaged into the repository.
+As always, due care with licensing *MUST* be taken when vendoring in this way.
+Supplimentary license details should be documented at the end of the LICENSE
+file. An example of doing so can be seen in the numpy codebase.
+
+

--- a/documents/scitools_licensing.md
+++ b/documents/scitools_licensing.md
@@ -15,7 +15,7 @@ in the [SciTools CLA](https://scitools.org.uk/cla/v4).
 The copyright statement is:
 
 ```
-Copyright © <start year>(-<end year>) <project> contributors
+Copyright <start year>(-<end year>) <project> contributors
 ```
 
 For example:

--- a/documents/scitools_licensing.md
+++ b/documents/scitools_licensing.md
@@ -15,13 +15,13 @@ in the [SciTools CLA](https://scitools.org.uk/cla/v4).
 The copyright statement is:
 
 ```
-Copyright (C) <start year>(-<end year>) <project> contributors
+Copyright © <start year>(-<end year>) <project> contributors
 ```
 
 For example:
 
 ```
-Copyright (C) 2010-2018 Iris contributors
+Copyright © 2010-2018 Iris contributors
 ```
 
 
@@ -31,7 +31,7 @@ All non-trivial source files in a SciTools repository must reference the
 license of the repository. The wording of the preamble should be:
 
 ```
-# Copyright (C) <project> contributors
+# Copyright © <project> contributors
 #
 # This file is part of <project> and is released under the <OSI license> license.
 # See LICENSE in the root of the repository for full licensing details.
@@ -48,7 +48,7 @@ The full text of a BSD 3-clause LICENSE file should be:
 ```
 BSD 3-Clause License
 
-Copyright (C) <YEAR_START>-<YEAR_END> <project> contributors
+Copyright © <YEAR_START>-<YEAR_END> <project> contributors
 
 See "Credits, copyright and license" in README.<ext> for full credits
 <(if appropriate) and any exceptions to the following terms>.


### PR DESCRIPTION
A heads up that I'm working with our legal team to simplify the licensing and CLA signing process of all SciTools libraries.

The ultimate aim is that all SciTools will be re-licensed as BSD 3-clause, rather than LGPL (we have received some highly ill-informed feedback stating that Iris is GPL and therefore couldn't be chosen for a project, rather than try to educate them, we have chosen to be more aligned with the licensing of other Python libraries (e.g. pandas)).

To limit the scope of this PR, I'm only documenting how we **license** SciTools projects here. I will create a similar PR for CLA and CLA signing process once this is done.

Take a look at this in rendered form at https://github.com/pelson/scitools.org.uk/blob/scitools_licensing_guide/documents/scitools_licensing.md.