### PR TITLE
Added a link to the scitools.org.uk Google account's CLA document and form

### DIFF
--- a/cla/v4/form/index.html
+++ b/cla/v4/form/index.html
@@ -1,0 +1,5 @@
+<html>
+    <head>
+    <meta http-equiv="Refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLSfd0tdE-DcJOXh8ej_7T93IizwJFYBFyRWYQOi2A8QRaKwykA/viewform">
+    </head>
+</html>

--- a/cla/v4/index.html
+++ b/cla/v4/index.html
@@ -1,0 +1,5 @@
+<html>
+    <head>
+    <meta http-equiv="Refresh" content="0; url=https://docs.google.com/document/d/1GOQxT5t4vc6i28OfghczAVz0tHUWHRsHGPcT1R5zTKk">
+    </head>
+</html>


### PR DESCRIPTION
Further to #209, this puts a placeholder in place for the next version of the SciTools CLA.
This does not put the CLA in action, and the CLA is not yet ready for (too deep) a review (though feel free to take a look if interested).

I basically want this to have consistent linking for a legal review.