### PR TITLE
Update build_status page with github links

### DIFF
--- a/build_status.html
+++ b/build_status.html
@@ -331,7 +331,6 @@
                        {org: 'SciTools', name: 'cf_units'},
                        {org: 'SciTools', name: 'iris-grib'},
                        {org: 'SciTools', name: 'nc-time-axis'},
-                       {org: 'SciTools', name: 'courses'},
                        {org: 'SciTools-incubator', name: 'python-stratify'},
                        {org: 'SciTools-incubator', name: 'iris-agg-regrid'},
                       ];
@@ -341,7 +340,11 @@
 
               function build_row(repo) {
                      return $('<tr>'
-                            + ' <td class="body-item mbr-fonts-style display-7">' + repo.name + '</td>'
+                            + ' <td class="body-item mbr-fonts-style display-7">'
+                            + '   <a href="https://github.com/' + repo.org + '/' + repo.name + '">'
+                            +       repo.name
+                            + '   </a>'
+                            + ' </td>'
                             + ' <td class="body-item mbr-fonts-style display-7">'
                             + '   <a href="https://github.com/' + repo.org + '/' + repo.name + '/releases">'
                             + '    <img src="https://img.shields.io/github/tag/' + repo.org + '/' + repo.name + '.svg?branch=master" alt="' + repo.name + '-tag" title="' + repo.name + '-tag">' 


### PR DESCRIPTION
A couple of changes that I think would be good for the [build status page on the scitools website](https://scitools.org.uk/build_status.html): 
* Update the package name column with links to the relevant github repos
* Removed the `courses` package because it doesn't have builds so almost all columns are just 'unknown'

One thing I really think would be a good is a having a link to the build_status page somewhere. I couldn't find one so I ended up having to manually type the url. The trouble is I couldn't think of a good place to put it which why I haven't included that change in this PR.