### PR TITLE
Fix some minor issues in Cartopy 0.17 docs.

### DIFF
--- a/cartopy/docs/v0.17/_modules/cartopy/crs.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/crs.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -2645,7 +2645,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/feature.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/feature.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -616,7 +616,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/io.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/io.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -542,7 +542,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/io/img_tiles.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/io/img_tiles.html
@@ -46,7 +46,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -660,7 +660,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/io/ogc_clients.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/io/ogc_clients.html
@@ -46,7 +46,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -986,7 +986,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/io/shapereader.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/io/shapereader.html
@@ -46,7 +46,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -704,7 +704,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/mpl/geoaxes.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/mpl/geoaxes.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -2093,7 +2093,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/mpl/gridliner.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/mpl/gridliner.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -565,7 +565,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/mpl/patch.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/mpl/patch.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -333,7 +333,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/mpl/slippy_image_artist.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/mpl/slippy_image_artist.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../../index.html">
 <img src="../../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -181,7 +181,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/cartopy/util.html
+++ b/cartopy/docs/v0.17/_modules/cartopy/util.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -219,7 +219,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_modules/index.html
+++ b/cartopy/docs/v0.17/_modules/index.html
@@ -44,7 +44,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -117,7 +117,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/_static/version_switch.js
+++ b/cartopy/docs/v0.17/_static/version_switch.js
@@ -60,7 +60,7 @@
            window.location.href = new_url;
         },
         error: function() {
-           window.location.href = 'http://scitools.org.uk/cartopy/docs/' + selected;
+           window.location.href = 'https://scitools.org.uk/cartopy/docs/' + selected;
         }
       });
     }

--- a/cartopy/docs/v0.17/cartopy.html
+++ b/cartopy/docs/v0.17/cartopy.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -171,7 +171,7 @@ example see <a class="reference internal" href="developer_interfaces.html#cartop
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy/geodesic.html
+++ b/cartopy/docs/v0.17/cartopy/geodesic.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -250,7 +250,7 @@ points.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy/io/img_tiles.html
+++ b/cartopy/docs/v0.17/cartopy/io/img_tiles.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -332,7 +332,7 @@ of flat, dark green.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy/io/ogc_clients.html
+++ b/cartopy/docs/v0.17/cartopy/io/ogc_clients.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -370,7 +370,7 @@ specified projection.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy/trace.html
+++ b/cartopy/docs/v0.17/cartopy/trace.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -160,7 +160,7 @@ into the destination projection.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy/util/util.html
+++ b/cartopy/docs/v0.17/cartopy/util/util.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../../index.html">
 <img src="../../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -192,7 +192,7 @@ the right-most dimension</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/cartopy_outline.html
+++ b/cartopy/docs/v0.17/cartopy_outline.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -575,7 +575,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/citation.html
+++ b/cartopy/docs/v0.17/citation.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -224,7 +224,7 @@ Depending on the policy, this may either be only the data source and license or 
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/contributors.html
+++ b/cartopy/docs/v0.17/contributors.html
@@ -48,7 +48,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -164,7 +164,7 @@ the package wouldn’t be as rich or diverse as it is today:</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/copyright.html
+++ b/cartopy/docs/v0.17/copyright.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -179,7 +179,7 @@ resource should be sent to: <a class="reference external" href="mailto:psi&#37;&
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/crs/index.html
+++ b/cartopy/docs/v0.17/crs/index.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -456,7 +456,7 @@ live internet connection is required.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/crs/projections.html
+++ b/cartopy/docs/v0.17/crs/projections.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -1038,7 +1038,7 @@ created.</li>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/developer_interfaces.html
+++ b/cartopy/docs/v0.17/developer_interfaces.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -439,7 +439,7 @@ slippy map type functionality.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/always_circular_stereo.html
+++ b/cartopy/docs/v0.17/gallery/always_circular_stereo.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -197,7 +197,7 @@ always be a circle.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/arrows.html
+++ b/cartopy/docs/v0.17/gallery/arrows.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -195,7 +195,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/aurora_forecast.html
+++ b/cartopy/docs/v0.17/gallery/aurora_forecast.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -261,7 +261,7 @@ data spaced equally in degrees from -180 to 180 and -90 to 90.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/axes_grid_basic.html
+++ b/cartopy/docs/v0.17/gallery/axes_grid_basic.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -221,7 +221,7 @@ of creating grid lines is used. Then some fake data is plotted.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/barbs.html
+++ b/cartopy/docs/v0.17/gallery/barbs.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -173,7 +173,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/eccentric_ellipse.html
+++ b/cartopy/docs/v0.17/gallery/eccentric_ellipse.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -217,7 +217,7 @@ matching eccentricity.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/effects_of_the_ellipse.html
+++ b/cartopy/docs/v0.17/gallery/effects_of_the_ellipse.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -258,7 +258,7 @@ coastlines are shifted as a result of referencing the incorrect ellipse.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/eyja_volcano.html
+++ b/cartopy/docs/v0.17/gallery/eyja_volcano.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -195,7 +195,7 @@ into a single image and displayed in the cartopy GeoAxes.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/favicon.html
+++ b/cartopy/docs/v0.17/gallery/favicon.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -199,7 +199,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/feature_creation.html
+++ b/cartopy/docs/v0.17/gallery/feature_creation.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -197,7 +197,7 @@ pre-defined <a class="reference internal" href="../matplotlib/feature_interface.
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/features.html
+++ b/cartopy/docs/v0.17/gallery/features.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -173,7 +173,7 @@ in cartopy.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/geostationary.html
+++ b/cartopy/docs/v0.17/gallery/geostationary.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -214,7 +214,7 @@ Projecting and plotting image (this may take a while)...
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/global_map.html
+++ b/cartopy/docs/v0.17/gallery/global_map.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -176,7 +176,7 @@ between two locations.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/hurricane_katrina.html
+++ b/cartopy/docs/v0.17/gallery/hurricane_katrina.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -240,7 +240,7 @@ have been significantly impacted by Hurricane Katrina.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/image_tiles.html
+++ b/cartopy/docs/v0.17/gallery/image_tiles.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -173,7 +173,7 @@ providing web service can be accessed.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/index.html
+++ b/cartopy/docs/v0.17/gallery/index.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -374,7 +374,7 @@ examples, see <a class="reference internal" href="../index.html#getting-started-
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/logo.html
+++ b/cartopy/docs/v0.17/gallery/logo.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -191,7 +191,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/nightshade.html
+++ b/cartopy/docs/v0.17/gallery/nightshade.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -165,7 +165,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/regridding_arrows.html
+++ b/cartopy/docs/v0.17/gallery/regridding_arrows.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -199,7 +199,7 @@ if the data is dense or warped.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/reprojected_wmts.html
+++ b/cartopy/docs/v0.17/gallery/reprojected_wmts.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -194,7 +194,7 @@ and Atmospheric Administration (NOAA).</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/rotated_pole.html
+++ b/cartopy/docs/v0.17/gallery/rotated_pole.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -185,7 +185,7 @@ that including the pole in the polygon has.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/star_shaped_boundary.html
+++ b/cartopy/docs/v0.17/gallery/star_shaped_boundary.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -178,7 +178,7 @@ star shaped boundary.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/streamplot.html
+++ b/cartopy/docs/v0.17/gallery/streamplot.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -171,7 +171,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/tick_labels.html
+++ b/cartopy/docs/v0.17/gallery/tick_labels.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -191,7 +191,7 @@ projections using special tick formatters.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/tissot.html
+++ b/cartopy/docs/v0.17/gallery/tissot.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -173,7 +173,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/tube_stations.html
+++ b/cartopy/docs/v0.17/gallery/tube_stations.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -214,7 +214,7 @@ resolution background imagery provided by OpenStreetMap.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/un_flag.html
+++ b/cartopy/docs/v0.17/gallery/un_flag.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -303,7 +303,7 @@ Equidistant projection to reproduce the UN flag.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/utm_all_zones.html
+++ b/cartopy/docs/v0.17/gallery/utm_all_zones.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -188,7 +188,7 @@ Finally we add a supertitle and display the figure.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/waves.html
+++ b/cartopy/docs/v0.17/gallery/waves.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -188,7 +188,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/wms.html
+++ b/cartopy/docs/v0.17/gallery/wms.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -168,7 +168,7 @@ supported by an OGC web services Web Map Service (WMS) aware axes.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/wmts.html
+++ b/cartopy/docs/v0.17/gallery/wmts.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -176,7 +176,7 @@ and Atmospheric Administration (NOAA).</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/gallery/wmts_time.html
+++ b/cartopy/docs/v0.17/gallery/wmts_time.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -197,7 +197,7 @@ the left, with the MODIS false color ‘snow RGB’ shown on the right.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/genindex.html
+++ b/cartopy/docs/v0.17/genindex.html
@@ -45,7 +45,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -689,7 +689,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/index.html
+++ b/cartopy/docs/v0.17/index.html
@@ -48,7 +48,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="#">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -189,7 +189,7 @@ re-designing its layout/logos etc.. The <a class="reference external" href="http
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/installing.html
+++ b/cartopy/docs/v0.17/installing.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -266,7 +266,7 @@ is only required to support the Cartopy unit tests.</dd>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/matplotlib/advanced_plotting.html
+++ b/cartopy/docs/v0.17/matplotlib/advanced_plotting.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -292,7 +292,7 @@ keyword and can have a massive impact on the effectiveness of the visualisation:
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/matplotlib/feature_interface.html
+++ b/cartopy/docs/v0.17/matplotlib/feature_interface.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -456,7 +456,7 @@ feature being plotted.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/matplotlib/geoaxes.html
+++ b/cartopy/docs/v0.17/matplotlib/geoaxes.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -860,7 +860,7 @@ or any type with a _as_mpl_path() method.</td>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/matplotlib/gridliner.html
+++ b/cartopy/docs/v0.17/matplotlib/gridliner.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -332,7 +332,7 @@ class to produce customized gridlines and tick labels:</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/matplotlib/intro.html
+++ b/cartopy/docs/v0.17/matplotlib/intro.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -260,7 +260,7 @@ geo-located images are provided for more advanced map based visualisations.</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/py-modindex.html
+++ b/cartopy/docs/v0.17/py-modindex.html
@@ -47,7 +47,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -143,7 +143,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/search.html
+++ b/cartopy/docs/v0.17/search.html
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -121,7 +121,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/tutorials/understanding_transform.html
+++ b/cartopy/docs/v0.17/tutorials/understanding_transform.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -260,7 +260,7 @@ for your plot and allow Cartopy to plot your data where it should be:</p>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/tutorials/using_the_shapereader.html
+++ b/cartopy/docs/v0.17/tutorials/using_the_shapereader.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="../index.html">
 <img src="../_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -306,7 +306,7 @@ Z Zimbabwe
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>

--- a/cartopy/docs/v0.17/whats_new.html
+++ b/cartopy/docs/v0.17/whats_new.html
@@ -52,7 +52,7 @@
         <div class="sphinxsidebarwrapper">
 <a href="index.html">
 <img src="_static/cartopy.png"
-border="0" alt="Cartopy" style="margin-left: -60px;"/>
+border="0" alt="Cartopy"/>
 </a>
 
 
@@ -970,7 +970,7 @@ module.</li>
     </div>
 
     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
-    <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
+    <script type="text/javascript" src="https://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 
 
   </body>


### PR DESCRIPTION
This comes from applying SciTools/cartopy#1218, which fixes the location of the logo and the loading of the version switcher.