### PR TITLE
Pointed iris latest to the read the docs instance

### DIFF
--- a/iris/docs/latest
+++ b/iris/docs/latest
@@ -1,1 +1,1 @@
-v2.4.0
+latest_readthedocs

--- a/iris/docs/latest_readthedocs/index.html
+++ b/iris/docs/latest_readthedocs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html dir="ltr" lang="en-gb">
+<head>
+<meta http-equiv="refresh" content="0; url=https://scitools-iris.readthedocs.io/en/latest/" />
+</head>
+<body>
+<p><a href="https://scitools-iris.readthedocs.io/en/latest/">Page has moved permanently</a></p>
+</body>
+</html>


### PR DESCRIPTION
A very small PR to update the **latest** documentation symbolic link to point to a **static web page** (new file) which will then auto redirect to the iris latest documentation host via https://scitools-iris.readthedocs.io/en/latest/

If this change is successful, when viewing https://scitools.org.uk/ when you click on the following it should redirect to https://scitools-iris.readthedocs.io/en/latest/

* *Iris* link on the main page (under the Iris logo)
* Menu: Documentation -> Iris

The new latest documentation includes a link to the **legacy documentation** on the sidebar, this will link to https://scitools.org.uk/iris/docs/v2.4.0/index.html so the older documentation may still be accessed.