### PR TITLE
Reverted latest to point to v2.4.0 for now.  

### DIFF
--- a/iris/docs/latest
+++ b/iris/docs/latest
@@ -1,1 +1,1 @@
-latest_readthedocs
+v2.4.0


### PR DESCRIPTION
This will change back once Iris 3.0.0 is released.