### PR TITLE
'Iris library' change to 'Iris package'

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
                 </a>
               </h4>
               <p class="mbr-text mbr-fonts-style display-7">
-                The <a href="/iris/docs/latest/">Iris</a> library implements
+                The <a href="/iris/docs/latest/">Iris</a> package implements
                 a data model to create a data abstraction layer which isolates
                 analysis and visualisation code from data format specifics.
                 The data model we have chosen is the CF Data Model.


### PR DESCRIPTION
This brings the **Iris headline** inline wit what is now on the latest Iris docs https://scitools-iris.readthedocs.io/en/latest/.