### PR TITLE
Add redirect to new cf-units readthedocs documentation

### DIFF
--- a/404.html
+++ b/404.html
@@ -121,7 +121,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Read the Docs.  The older documentation (Iris 2.4 and earlier) will still be pre
 in this repo, and as of today should no longer need to be updated via this repo,
 only via the Iris repo and then automatically built and served by Read the Docs.
 
+cf-units is also provisioned by Read the Docs (https://cf-units.readthedocs.io/en/stable/)
+since the cf-units v3.0.0 release. Older documentation (v2.0 and earlier) lives
+in this repo.
 
 Example workflow
 ----------------

--- a/build_status.html
+++ b/build_status.html
@@ -117,7 +117,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>

--- a/cf-units/docs/index.html
+++ b/cf-units/docs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html dir="ltr" lang="en-gb">
+<head>
+<meta http-equiv="refresh" content="0; url=/cf-units/docs/stable/" />
+</head>
+<body>
+<p><a href="/cf-units/docs/stable">Page has moved permanently</a></p>
+</body>
+</html>

--- a/cf-units/docs/latest
+++ b/cf-units/docs/latest
@@ -1,1 +1,1 @@
-v2.0
+latest_readthedocs

--- a/cf-units/docs/latest_readthedocs/index.html
+++ b/cf-units/docs/latest_readthedocs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html dir="ltr" lang="en-gb">
+<head>
+<meta http-equiv="refresh" content="0; url=https://cf-units.readthedocs.io/en/latest/" />
+</head>
+<body>
+<p><a href="https://cf-units.readthedocs.io/en/latest/">Page has moved permanently</a></p>
+</body>
+</html>

--- a/cf-units/docs/stable
+++ b/cf-units/docs/stable
@@ -1,0 +1,1 @@
+stable_readthedocs

--- a/cf-units/docs/stable_readthedocs/index.html
+++ b/cf-units/docs/stable_readthedocs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html dir="ltr" lang="en-gb">
+<head>
+<meta http-equiv="refresh" content="0; url=ahttps://cf-units.readthedocs.io/en/stable/" />
+</head>
+<body>
+<p><a href="https://cf-units.readthedocs.io/en/stable/">Page has moved permanently</a></p>
+</body>
+</html>

--- a/cf-units/index.html
+++ b/cf-units/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html dir="ltr" lang="en-gb">
+<head>
+<meta http-equiv="refresh" content="0; url=/cf-units/docs/stable/" />
+</head>
+<body>
+<p><a href="/cf-units/docs/stable">Page has moved permanently</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>
@@ -313,10 +313,10 @@
         <ul>
             <li>
             <a class="anchor" name="cf-units" id="cf-units"></a>
-              <a href="/cf-units/docs/latest/"><b>cf-units</b></a> -
+              <a href="/cf-units/docs/stable/"><b>cf-units</b></a> -
               is a wrapper class to support Unidata/UCAR UDUNITS-2, and the
               netcdftime calendar functionality. Provides units of measure.
-              <a href="/cf-units/docs/latest/">Learn more...</a>
+              <a href="/cf-units/docs/stable/">Learn more...</a>
             </li>
             <li>
               <a href="https://iris-grib.readthedocs.io/en/latest/"><b>iris-grib</b></a> -

--- a/organisation.html
+++ b/organisation.html
@@ -117,7 +117,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>

--- a/privacy.html
+++ b/privacy.html
@@ -117,7 +117,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>

--- a/signed_cla.html
+++ b/signed_cla.html
@@ -117,7 +117,7 @@
               iris-grib
               </a>
               <a class="text-white dropdown-item display-4"
-                 href="/cf-units/docs/latest/"
+                 href="/cf-units/docs/stable/"
                  aria-expanded="false">
               cf-units
               </a>


### PR DESCRIPTION
Fixes #249 

scitools.org.uk still points to the old cf-units docs so this needs updating.

I have based the changes in this PR on #153 

In summary:
* Added a stable symlink under `cf-units/docs`
* Replaced links to `/cf-units/docs/latest` with links to `/cf-units/docs/stable`
* Added `Page has moved permanently` index.html to each level (as is done for Iris)
  * `cf-units/index.html`
  * `cf-units/docs/index.html`
  * `cf-units/docs/stable/index.html`
  * `cf-units/docs/latest/index.html`
