### PR TITLE
Fix typo in redirect html

### DIFF
--- a/cf-units/docs/stable_readthedocs/index.html
+++ b/cf-units/docs/stable_readthedocs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html dir="ltr" lang="en-gb">
 <head>
-<meta http-equiv="refresh" content="0; url=ahttps://cf-units.readthedocs.io/en/stable/" />
+<meta http-equiv="refresh" content="0; url=https://cf-units.readthedocs.io/en/stable/" />
 </head>
 <body>
 <p><a href="https://cf-units.readthedocs.io/en/stable/">Page has moved permanently</a></p>


### PR DESCRIPTION
Fix a typo in the url to cf-units, added in #250