### PR TITLE
add archive doc files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+iris/docs/archive/*.zip filter=lfs diff=lfs merge=lfs -text

--- a/iris/docs/README
+++ b/iris/docs/README
@@ -1,1 +1,6 @@
 This folder should contain MAJOR.MINOR documentation only.
+
+As of 14/11/2022 an archive was created to keep a zip file of each
+Iris release that is not hosted on Read The Docs.  This includes Iris v2.4
+and earlier.  The archive is located in /iris/docs/archive.  All built
+older documentaiton will then shortly be removed from the repo.

--- a/iris/docs/archive/v0.9.1.zip
+++ b/iris/docs/archive/v0.9.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbdb977f39456dedbb842f232a43386d5244053936f8ebf4e7e5f58c325904e5
+size 4644601

--- a/iris/docs/archive/v1.0.zip
+++ b/iris/docs/archive/v1.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:983d6446b86d7b3cb47113ccb0b90aaa5fa52d03d52d69140b40c168ca6e84e8
+size 5357091

--- a/iris/docs/archive/v1.1.zip
+++ b/iris/docs/archive/v1.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7777f8b0c556490b3de3e3157287b46246fa78a80627cd93232206a3132d9d4
+size 5329053

--- a/iris/docs/archive/v1.10.0.zip
+++ b/iris/docs/archive/v1.10.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40e63a2a6a1ea9a7b4916043092003fe8cb21d7edbf1dc081bc254498eabd2dd
+size 13021389

--- a/iris/docs/archive/v1.11.0.zip
+++ b/iris/docs/archive/v1.11.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:706e8937a4dcdee304857ad9a4dbc46bc40217894d1ef77f9c47c3a86056d410
+size 13565808

--- a/iris/docs/archive/v1.12.0.zip
+++ b/iris/docs/archive/v1.12.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf036311c029c89f929ccce8818548996e7f8e8cdb7776185d8a4b07fedd784d
+size 13600953

--- a/iris/docs/archive/v1.13.0.zip
+++ b/iris/docs/archive/v1.13.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d33441dcf507a862f852a270b80c78f9d4ac6d6c35418ffde6b52ea9d92479bc
+size 13181852

--- a/iris/docs/archive/v1.2.zip
+++ b/iris/docs/archive/v1.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6dffeefc57450bef13332dcd3d663f7fdc89884e0273a00684a40ad9a22dfba
+size 5487215

--- a/iris/docs/archive/v1.3.zip
+++ b/iris/docs/archive/v1.3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f46ff98e9962550593be8bf51145a2eb06d1e8390cf809d652fa6b903f49549
+size 5466302

--- a/iris/docs/archive/v1.4.zip
+++ b/iris/docs/archive/v1.4.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97883976ed35a4183aa5af1c25db60a0d2346665f6923be26abbc2d031997c81
+size 5498415

--- a/iris/docs/archive/v1.5.zip
+++ b/iris/docs/archive/v1.5.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb37d455711a7b55e6be510ce224202d55a4a330c7cd0cbd6536b3786c2bf910
+size 5794680

--- a/iris/docs/archive/v1.6.zip
+++ b/iris/docs/archive/v1.6.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed18a1a50f812b382c75ea5f8a215f1a851bfbe77c836e2624b74180accd2700
+size 5820618

--- a/iris/docs/archive/v1.7.2.zip
+++ b/iris/docs/archive/v1.7.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eef7e13363f4144b66f17d35d6e985e492d640e65e381715192da78d91146f5
+size 7820545

--- a/iris/docs/archive/v1.7.3.zip
+++ b/iris/docs/archive/v1.7.3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:534796a3f91fe4670738d38ff6ada7c4c16e78c4b6dc6a9b5f0464d57f6674a3
+size 7811732

--- a/iris/docs/archive/v1.7.zip
+++ b/iris/docs/archive/v1.7.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa0fe64538b70d60d57c2e9a91e6623aa2aa067eea5cf4dbad260da1b367dc5
+size 7784233

--- a/iris/docs/archive/v1.8.0.zip
+++ b/iris/docs/archive/v1.8.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc67ea63d9cd301d9cc78f8b025284b8e72c0d1cd9d574fb732780c6e602892f
+size 8400664

--- a/iris/docs/archive/v1.8.1.zip
+++ b/iris/docs/archive/v1.8.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d686b9c6c0107a2d3011c8c58c60715aa7c0cee6384695b84959ad0d0dae54a3
+size 13643130

--- a/iris/docs/archive/v1.9.0.zip
+++ b/iris/docs/archive/v1.9.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c3293b3b043d3f5e5b6fe7b70eb3a58a1f858653809b92d40de6f8cfb965c96
+size 16715260

--- a/iris/docs/archive/v1.9.1.zip
+++ b/iris/docs/archive/v1.9.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b9df3daa8da124da06c7c480e211a434650728e19d16730fd89c28203548bf1
+size 12756427

--- a/iris/docs/archive/v1.9.2.zip
+++ b/iris/docs/archive/v1.9.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8bf88f03a059b61c9c34f0c62b096e5372840884cee1a91e102f95370af5175
+size 12766348

--- a/iris/docs/archive/v2.0.zip
+++ b/iris/docs/archive/v2.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b5049a3592f7bdc64e8ba36c174ac7de0db85baf0066b305cf5f1e6ad043aee
+size 13726698

--- a/iris/docs/archive/v2.1.zip
+++ b/iris/docs/archive/v2.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ec0f83767498bdbfa2a611f5ade2bc58889ac986faef81def719f62d768a791
+size 12285472

--- a/iris/docs/archive/v2.2.1.zip
+++ b/iris/docs/archive/v2.2.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d96b1248bfef7c989d7224e7bc533db0f82f058f396edbaefcd11e03db936c20
+size 11734140

--- a/iris/docs/archive/v2.2.zip
+++ b/iris/docs/archive/v2.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fc0a9beb6e03338d09f33d4c2960b55e6f80135e403cc51b7f8f851a768e7dc
+size 11634373

--- a/iris/docs/archive/v2.3.0.zip
+++ b/iris/docs/archive/v2.3.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b071368bd6621c7b1ef0567c68f9d4a8d085d50c86e58d3c3ecf952c200bdaa7
+size 14175053

--- a/iris/docs/archive/v2.4.0.zip
+++ b/iris/docs/archive/v2.4.0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d073d2ba0b3d171884230df2705f84bf3817575264b042ae741821ba35d6d670
+size 14268702


### PR DESCRIPTION
Create a new **archive** folder with all older docs as zip files using [Git LFS](https://git-lfs.github.com/).

This PR does **NOT** remove the old uncompressed docs, that will come later.

Related to https://github.com/SciTools/iris/issues/4396#issuecomment-1310663359 (step 1)